### PR TITLE
Check freeze_list_index and reject redundant update_freeze_list

### DIFF
--- a/programs/merkle_tree.leo
+++ b/programs/merkle_tree.leo
@@ -50,7 +50,7 @@ program merkle_tree.aleo {
             // Ensure the address is in between the provided leavess
             assert(addr_field > merkle_proofs[0u32].siblings[0u32]);
             assert(addr_field < merkle_proofs[1u32].siblings[0u32]);
-            // Ensure the leavess are adjacent
+            // Ensure the leaves are adjacent
             assert_eq(merkle_proofs[0u32].leaf_index + 1u32, merkle_proofs[1u32].leaf_index);
         }
         

--- a/programs/sealance_freezelist_registry.leo
+++ b/programs/sealance_freezelist_registry.leo
@@ -52,8 +52,28 @@ program sealance_freezelist_registry.aleo {
         freeze_list_root.set(PREVIOUS_FREEZE_LIST_ROOT_INDEX, old_root);
         freeze_list_root.set(CURRENT_FREEZE_LIST_ROOT_INDEX, new_root);
 
+        // Verify we don't unfreeze an unfrozen account or freeze a frozen account
+        let stored_is_freezed = freeze_list.get_or_use(account, false);
+        assert_neq(is_freezed, stored_is_freezed);
         freeze_list.set(account, is_freezed);
-        freeze_list_index.set(freezed_index, is_freezed ? account : ZERO_ADDRESS);
+
+        let current_freezed_index: address = freeze_list_index.get_or_use(freezed_index, ZERO_ADDRESS);
+        if (is_freezed) {
+            // Verify that the freezed_index is empty.
+            assert_eq(current_freezed_index, ZERO_ADDRESS);
+            
+            // If the freezed_index is greater than 0 we verify that the prior_freezed_index is not empty
+            if (freezed_index > 0u32) {
+                let prior_freezed_index: address = freeze_list_index.get_or_use(freezed_index - 1u32, ZERO_ADDRESS);
+                assert_neq(prior_freezed_index, ZERO_ADDRESS);
+            }
+            
+            freeze_list_index.set(freezed_index, account);
+        } else {
+            // Verify that we update the correct freezed_index
+            assert_eq(current_freezed_index, account);
+            freeze_list_index.set(freezed_index, ZERO_ADDRESS);
+        }
 
         root_updated_height.set(ROOT_UPDATED_HEIGHT_INDEX, block.height);
     }

--- a/programs/sealed_report_policy.leo
+++ b/programs/sealed_report_policy.leo
@@ -51,8 +51,28 @@ program sealed_report_policy.aleo {
         freeze_list_root.set(PREVIOUS_FREEZE_LIST_ROOT_INDEX, old_root);
         freeze_list_root.set(CURRENT_FREEZE_LIST_ROOT_INDEX, new_root);
 
+        // Verify we don't unfreeze an unfrozen account or freeze a frozen account
+        let stored_is_freezed = freeze_list.get_or_use(account, false);
+        assert_neq(is_freezed, stored_is_freezed);
         freeze_list.set(account, is_freezed);
-        freeze_list_index.set(freezed_index, is_freezed ? account : ZERO_ADDRESS);
+
+        let current_freezed_index: address = freeze_list_index.get_or_use(freezed_index, ZERO_ADDRESS);
+        if (is_freezed) {
+            // Verify that the freezed_index is empty
+            assert_eq(current_freezed_index, ZERO_ADDRESS);
+            
+            // If the freezed_index is greater than 0 we verify that the prior_freezed_index is not empty
+            if (freezed_index > 0u32) {
+                let prior_freezed_index: address = freeze_list_index.get_or_use(freezed_index - 1u32, ZERO_ADDRESS);
+                assert_neq(prior_freezed_index, ZERO_ADDRESS);
+            }
+            
+            freeze_list_index.set(freezed_index, account);
+        } else {
+            // Verify we update the correct freezed_index
+            assert_eq(current_freezed_index, account);
+            freeze_list_index.set(freezed_index, ZERO_ADDRESS);
+        }
 
         root_updated_height.set(ROOT_UPDATED_HEIGHT_INDEX, block.height);
     }


### PR DESCRIPTION
- Verify that the admin selects the correct freeze_list_index.
- Assert that the admin does not unfreeze a user who is not frozen.
- Assert that the admin does not freeze a user who is already frozen.
- Test those changes
