### PR TITLE
Fix freeze list test clashes

### DIFF
--- a/.github/workflows/reusable-aleo-test.yml
+++ b/.github/workflows/reusable-aleo-test.yml
@@ -76,7 +76,7 @@ jobs:
         uses: sealance-io/setup-doko-js-action@v0.1.0
         with:
           doko-repo: "sealance-io/doko-js"
-          doko-branch: "fixes_to_dokojs"
+          doko-branch: "0ae61e5854006dbc6dcc1fe5d7f9f39a2e1648e4"
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"

--- a/lib/Initalize.ts
+++ b/lib/Initalize.ts
@@ -1,0 +1,10 @@
+import { CURRENT_FREEZE_LIST_ROOT_INDEX } from "./Constants";
+
+export async function isProgramInitialized(program: any) {
+  try {
+    await program.freeze_list_root(CURRENT_FREEZE_LIST_ROOT_INDEX);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/test/timelock.test.ts
+++ b/test/timelock.test.ts
@@ -27,6 +27,7 @@ import { buildTree, genLeaves } from "../lib/MerkleTree";
 import type { Token } from "../artifacts/js/types/token_registry";
 import type { CompliantToken } from "../artifacts/js/types/sealed_timelock_policy";
 import { updateAdminRole } from "../lib/Role";
+import { isProgramInitialized } from "../lib/Initalize";
 
 const mode = ExecutionMode.SnarkExecute;
 const contract = new BaseContract({ mode });
@@ -232,18 +233,24 @@ describe("test compliant_timelock_transfer program", () => {
   test(
     `freeze registry setup`,
     async () => {
-      const tx1 = await freezeRegistryContract.initialize(BLOCK_HEIGHT_WINDOW);
-      await tx1.wait();
+      const isFreezeRegistryInitialized = await isProgramInitialized(freezeRegistryContract);
+      if (!isFreezeRegistryInitialized) {
+        const tx1 = await freezeRegistryContract.initialize(BLOCK_HEIGHT_WINDOW);
+        await tx1.wait();
+      }
 
       await updateAdminRole(freezeRegistryContractForAdmin, adminAddress);
 
-      const tx2 = await freezeRegistryContractForAdmin.update_freeze_list(frozenAccount, true, 0, root);
-      await tx2.wait();
-      const isAccountFrozen = await freezeRegistryContract.freeze_list(frozenAccount);
-      const frozenAccountByIndex = await freezeRegistryContract.freeze_list_index(0);
+      let isAccountFrozen = await freezeRegistryContract.freeze_list(frozenAccount, false);
+      if (!isAccountFrozen) {
+        const tx2 = await freezeRegistryContractForAdmin.update_freeze_list(frozenAccount, true, 0, root);
+        await tx2.wait();
+        const isAccountFrozen = await freezeRegistryContract.freeze_list(frozenAccount);
+        const frozenAccountByIndex = await freezeRegistryContract.freeze_list_index(0);
 
-      expect(isAccountFrozen).toBe(true);
-      expect(frozenAccountByIndex).toBe(frozenAccount);
+        expect(isAccountFrozen).toBe(true);
+        expect(frozenAccountByIndex).toBe(frozenAccount);
+      }
 
       const tx3 = await freezeRegistryContractForAdmin.update_block_height_window(300);
       await tx3.wait();


### PR DESCRIPTION
This PR fixes clashes in freeze list tests by adding guards:
- Skip initialization if the freeze list is already initialized.
- Skip updates if an account is already frozen.

This ensures tests run independently without state conflicts.