### PR TITLE
Implement and test the stable_token program

### DIFF
--- a/lib/Constants.ts
+++ b/lib/Constants.ts
@@ -82,6 +82,7 @@ export const SUPPLY_MANAGER_ROLE = 3;
 
 // merkle tree
 export const MAX_TREE_SIZE = 16;
+export const TREE_DEPTH_12 = 13;
 
 // testing constant
 export const defaultAuthorizedUntil = 4294967295;

--- a/programs/sealed_stable_token.leo
+++ b/programs/sealed_stable_token.leo
@@ -1,0 +1,971 @@
+program sealed_stable_token.aleo {
+    @custom
+    async constructor() {
+        let admin_address: address = roles.get_or_use(ADMIN_INDEX, self.program_owner);
+        assert_eq(admin_address, self.program_owner);
+    }
+
+    record Token {
+        owner: address,
+        amount: u128
+    }
+
+    // Compliance record used for the investigator
+    record ComplianceRecord {
+        owner: address,
+        amount: u128,
+        sender: address,
+        recipient: address
+    }
+
+    record Credentials {
+        owner: address,
+        freeze_list_root: field,
+    }
+
+    struct MerkleProof {
+        siblings: [field; MAX_TREE_DEPTH+1],
+        leaf_index: u32
+    }
+
+    struct TokenMetadata {
+        name: u128, // ASCII text represented in bits, and the u128 value of the bitstring
+        symbol: u128, // ASCII text represented in bits, and the u128 value of the bitstring
+        decimals: u8,
+        supply: u128,
+        max_supply: u128,
+    }
+
+    struct Allowance {
+        account: address,
+        spender: address,
+    }
+    
+    const TOKEN_METADATA_INDEX: bool = true;
+    // token specs
+    mapping token_metadata: bool => TokenMetadata;
+
+    mapping balances: address => u128;
+    mapping allowances: field => u128; // hash(account, spender) => Allowance
+
+    const NONE_ROLE: u8 = 0u8;
+    const MINTER_ROLE: u8 = 1u8;
+    const BURNER_ROLE: u8 = 2u8;
+    const SUPPLY_MANAGER_ROLE: u8 = 3u8;
+    mapping supply_roles: address => u8;
+
+
+        // Admin: can assign roles, assign supply roles, mint assets, burn assets, update the freeze list and upgrade the program
+        const ADMIN_INDEX: u8 = 1u8;
+        // Investigator: receives compliant records with transaction details
+        const INVESTIGATOR_INDEX: u8 = 2u8;
+        // Freeze list manager: can update the freeze list
+        const FREEZE_LIST_MANAGER_INDEX: u8 = 4u8;
+    // Maps a role ID to an address (e.g., 1 = admin).
+    mapping roles: u8 => address;
+
+    const CURRENT_FREEZE_LIST_ROOT_INDEX: u8 = 1u8;
+    const PREVIOUS_FREEZE_LIST_ROOT_INDEX: u8 = 2u8;
+    const ROOT_UPDATED_HEIGHT_INDEX: bool = true;
+    const BLOCK_HEIGHT_WINDOW_INDEX: bool = true;
+    const FREEZE_LIST_LAST_INDEX: bool = true;
+
+    const ZERO_ADDRESS: address = aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc; // ZERO_ADDRESS as field equals to 0field
+    const EMPTY_ROOT: field = 7233124799133753665783241350706390908532988676951941973288057571394699151001field; // hash of H(ZERO_ADDRESS, ZERO_ADDRESS)
+    
+    // Defines the maximum depth of the Merkle tree used in freeze list proofs.
+    // Trees deeper than this value are not supported.
+    const MAX_TREE_DEPTH: u32 = 12u32;
+
+    // Indicates whether an address is frozen.
+    mapping freeze_list: address => bool;
+    // Mimics an array of frozen addresses by storing them at sequential indexes.
+    mapping freeze_list_index: u32 => address;
+    // Stores the highest index used in the freeze_list_index mapping.
+    mapping freeze_list_last_index: bool => u32;
+    // Stores the current and previous Merkle roots of the freeze list (e.g., 1 = current, 2 = previous).
+    mapping freeze_list_root: u8 => field;
+    // Stores the block height when the root was updated.
+    mapping root_updated_height: bool => u32;
+    // Defines the number of blocks during which the previous root is still considered valid.
+    mapping block_height_window: bool => u32;
+
+    // -------------------------
+    // Called by token admins
+    // -------------------------
+
+    // Freezes or unfreezes an account based on the is_frozen flag (true = freeze, false = unfreeze).
+    // Can only be called after the contract has been initialized.
+    // Verifies that the operation is valid:
+    // - Cannot freeze an already frozen account or unfreeze an account that isn't frozen.
+    // - When freezing:
+    //   - Ensures the target index in freeze_list_index is empty.
+    //   - Ensures the index is not greater than the last index + 1.
+    //   - If the index equals last index + 1, updates freeze_list_last_index.
+    // - When unfreezing:
+    //   - Ensures the specified index currently holds the account being removed.
+    // Requires the previous_root to prevent the admin from unintentionally overwriting updates.
+    // Updates both the freeze_list and freeze_list_index mappings accordingly.
+    // Also updates the current Merkle root and stores the previous root for backward compatibility.
+    // Can only be called by the admin and the freeze list manager.
+    async transition update_freeze_list(
+        public account: address, 
+        public is_frozen: bool, 
+        public frozen_index: u32, 
+        public previous_root: field,
+        public new_root: field
+    ) -> Future {
+        return f_update_freeze_list(account, is_frozen, frozen_index, self.caller, previous_root, new_root);
+    }
+    async function f_update_freeze_list(account: address, is_frozen: bool, frozen_index: u32, caller: address, previous_root: field, new_root: field) {
+        let admin_address: address = roles.get(ADMIN_INDEX);
+        if(admin_address != caller) {
+            let freeze_list_manager_address: address = roles.get(FREEZE_LIST_MANAGER_INDEX);
+            assert_eq(freeze_list_manager_address, caller);
+        }
+
+        let old_root: field = freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+        assert_eq(previous_root, old_root);
+        freeze_list_root.set(PREVIOUS_FREEZE_LIST_ROOT_INDEX, old_root);
+        freeze_list_root.set(CURRENT_FREEZE_LIST_ROOT_INDEX, new_root);
+
+        // Verify we don't unfreeze an unfrozen account or freeze a frozen account
+        let stored_is_frozen = freeze_list.get_or_use(account, false);
+        assert_neq(is_frozen, stored_is_frozen);
+        freeze_list.set(account, is_frozen);
+
+        let current_address_at_index: address = freeze_list_index.get_or_use(frozen_index, ZERO_ADDRESS);
+        if (is_frozen) {
+            // Verify that the frozen_index is empty
+            assert_eq(current_address_at_index, ZERO_ADDRESS);
+
+            // Verify that the frozen index equal or smaller than the last index plus 1
+            let last_index: u32 = freeze_list_last_index.get(FREEZE_LIST_LAST_INDEX);
+            assert(last_index + 1u32 >= frozen_index);
+        
+            // Update the freeze_list_last_index
+            if (last_index < frozen_index) {
+                freeze_list_last_index.set(FREEZE_LIST_LAST_INDEX, frozen_index);
+            }
+
+            freeze_list_index.set(frozen_index, account);
+        } else {
+            // Verify we update the correct frozen_index
+            assert_eq(current_address_at_index, account);
+            freeze_list_index.set(frozen_index, ZERO_ADDRESS);
+        }
+
+        root_updated_height.set(ROOT_UPDATED_HEIGHT_INDEX, block.height);
+    }
+
+    // Updates the address assigned to a given role.
+    // Can only be called by the current admin.
+    // If no admin is set yet, the caller is temporarily treated as admin.
+    async transition update_role(public new_address: address, role: u8) -> Future {
+        return f_update_role(new_address, self.caller, role);
+    }
+    async function f_update_role(new_address: address, caller: address, role: u8) {
+        let admin_address: address = roles.get_or_use(ADMIN_INDEX, caller);
+        assert_eq(admin_address, caller);
+        roles.set(role, new_address);
+    }
+
+    // Updates the number of blocks during which the previous root is still considered valid.
+    // Can only be called by the admin.
+    async transition update_block_height_window(public blocks: u32) -> Future {
+        return f_update_block_height_window(blocks, self.caller);
+    }
+    async function f_update_block_height_window(blocks: u32, caller: address) {
+        let admin_address: address = roles.get(ADMIN_INDEX);
+        assert_eq(admin_address, caller);
+
+        block_height_window.set(BLOCK_HEIGHT_WINDOW_INDEX, blocks);
+    }
+
+    // Assigns a supply role (minter, burner, or supply manager) to the given address.
+    // Can only be called by the current admin.
+    async transition update_supply_role(public new_address: address, role: u8) -> Future {
+        return f_update_supply_role(new_address, self.caller, role);
+    }
+    async function f_update_supply_role(new_address: address, caller: address, role: u8) {
+        let admin_address: address = roles.get(ADMIN_INDEX);
+        assert_eq(admin_address, caller);
+
+        supply_roles.set(new_address, role);
+    }
+
+    // Initializes the freeze list and token specifications.
+    // Can only be called once — ensures the contract has not already been initialized.    
+    // Sets the token metadata (name, symbol, decimals, max supply).
+    // Sets the block height window, the initial empty Merkle root,
+    // and initialize the freeze_list_last_index, freeze_list, and freeze_list_index with a ZERO_ADDRESS placeholder.
+    async transition initialize(
+        public name: u128,
+        public symbol: u128,
+        public decimals: u8,
+        public max_supply: u128,
+        public blocks: u32
+    ) -> Future {
+        return finalize_initialize(
+            name,
+            symbol,
+            decimals,
+            max_supply,
+            blocks
+        );
+    }
+    async function finalize_initialize(
+        name: u128,
+        symbol: u128,
+        decimals: u8,
+        max_supply: u128,
+        blocks: u32
+    ) {
+        // Check if the token has already been initialized
+        let already_initialized: bool = token_metadata.contains(TOKEN_METADATA_INDEX);
+        assert_eq(already_initialized, false);
+        
+        let token: TokenMetadata = TokenMetadata {
+            name: name,
+            symbol: symbol,
+            decimals: decimals,
+            supply: 0u128, // placeholder value; not used
+            max_supply: max_supply
+        };
+
+        token_metadata.set(TOKEN_METADATA_INDEX, token);
+
+        block_height_window.set(BLOCK_HEIGHT_WINDOW_INDEX, blocks);
+        freeze_list_last_index.set(FREEZE_LIST_LAST_INDEX, 0u32);
+        freeze_list_root.set(CURRENT_FREEZE_LIST_ROOT_INDEX, EMPTY_ROOT);
+        freeze_list.set(ZERO_ADDRESS, false);
+        freeze_list_index.set(0u32, ZERO_ADDRESS);
+    }
+
+    // Generates a Credentials record for the signer.
+    // Allows future private transfers without needing to re-prove non-inclusion in the freeze list.
+    // The signer's privacy is preserved by proving non-inclusion in the freeze list Merkle tree.
+    async transition get_credentials(sender_merkle_proofs: [MerkleProof;2]) -> (Credentials, Future) {
+        let root: field = verify_non_inclusion(self.signer, sender_merkle_proofs);
+
+        let creds_record: Credentials = Credentials {
+            owner: self.signer,
+            freeze_list_root: root,
+        };
+
+        return (creds_record, f_get_credentials(root));
+    }
+    async function f_get_credentials(root: field) {
+        let current_root: field = freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+        let window: u32 = block_height_window.get_or_use(BLOCK_HEIGHT_WINDOW_INDEX, 0u32);
+
+        if (current_root != root) {
+            let previous_root: field = freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+            assert_eq(root, previous_root);
+            let updated_height: u32 = root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+            assert(updated_height + window > block.height);
+        }
+    }
+
+    // Mints new public tokens to the specified recipient’s balance.
+    // Can be called by the admin, a minter, or a supply manager.
+    // Ensures that the new total supply does not exceed the maximum supply.
+    // Updates the recipient’s balance and the total token supply in the token metadata.
+    async transition mint_public(
+        public recipient: address,
+        public amount: u128,
+    ) -> Future {
+        return finalize_mint_public(recipient, amount, self.caller);
+    }
+    async function finalize_mint_public(
+        recipient: address,
+        amount: u128,
+        caller: address
+    ) {
+        let admin_address: address = roles.get_or_use(ADMIN_INDEX, caller);
+        let is_admin: bool = caller == admin_address;
+        if(!is_admin) {
+            let role: u8 = supply_roles.get(caller);
+            assert(role == MINTER_ROLE || role == SUPPLY_MANAGER_ROLE);
+        }
+
+        let token = token_metadata.get(TOKEN_METADATA_INDEX);
+
+        // Check that the token supply + amount <= max_supply
+        let new_supply: u128 = token.supply + amount;
+        assert(new_supply <= token.max_supply);
+
+        // Update the balance
+        let balance = balances.get_or_use(recipient, 0u128);
+        let new_balance = amount + balance;
+        balances.set(recipient, new_balance);
+
+        // Update the token supply
+        let new_metadata: TokenMetadata = TokenMetadata {
+            name: token.name,
+            symbol: token.symbol,
+            decimals: token.decimals,
+            supply: new_supply,
+            max_supply: token.max_supply,
+        };
+        token_metadata.set(TOKEN_METADATA_INDEX, new_metadata);
+    }
+
+    // Mints new private tokens to the specified recipient.
+    // Can be called by the admin, a minter, or a supply manager.
+    // Ensures that the new total supply does not exceed the maximum supply.
+    // Updates the total token supply in the token metadata.
+    async transition mint_private(
+        recipient: address,
+        public amount: u128
+        ) -> (Token, Future) {
+        let token: Token = Token {
+            owner: recipient,
+            amount: amount,
+        };
+        return (token, finalize_mint_private(amount, self.caller));
+    }
+
+    async function finalize_mint_private(
+        amount: u128,
+        caller: address,
+    ) {
+        let admin_address: address = roles.get_or_use(ADMIN_INDEX, caller);
+        let is_admin: bool = caller == admin_address;
+        if(!is_admin) {
+            let role: u8 = supply_roles.get(caller);
+            assert(role == MINTER_ROLE || role == SUPPLY_MANAGER_ROLE);
+        }
+
+        let token = token_metadata.get(TOKEN_METADATA_INDEX);
+
+        // Check that the token supply + amount <= max_supply
+        let new_supply: u128 = token.supply + amount;
+        assert(new_supply <= token.max_supply);
+
+        // Update the token supply
+        let new_metadata: TokenMetadata = TokenMetadata {
+            name: token.name,
+            symbol: token.symbol,
+            decimals: token.decimals,
+            supply: new_supply,
+            max_supply: token.max_supply,
+        };
+        token_metadata.set(TOKEN_METADATA_INDEX, new_metadata);
+    }
+
+    // Burns public tokens from the specified owner’s balance.
+    // Can be called by the admin, a burner, or a supply manager.
+    // Decreases the owner’s balance and reduces the total token supply in the token metadata.
+    async transition burn_public(
+        public owner: address,
+        public amount: u128
+    ) -> Future {
+        return finalize_burn_public(owner, amount, self.caller);
+    }
+
+    async function finalize_burn_public(
+        owner: address,
+        amount: u128,
+        caller: address,
+    ) {
+        let admin_address: address = roles.get_or_use(ADMIN_INDEX, caller);
+        let is_admin: bool = caller == admin_address;
+        if(!is_admin) {
+            let role: u8 = supply_roles.get(caller);
+            assert(role == BURNER_ROLE || role == SUPPLY_MANAGER_ROLE);
+        }
+
+        // Update the balance
+        let balance = balances.get(owner);
+        let new_balance = balance - amount;
+        balances.set(owner, new_balance);
+
+        let token = token_metadata.get(TOKEN_METADATA_INDEX);
+
+        let new_metadata: TokenMetadata = TokenMetadata {
+            name: token.name,
+            symbol: token.symbol,
+            decimals: token.decimals,
+            supply: token.supply - amount, // underflow will be caught by the VM
+            max_supply: token.max_supply,
+        };
+        token_metadata.set(TOKEN_METADATA_INDEX, new_metadata);
+    }
+
+    // Burns tokens from a private record (non-public asset).
+    // Can be called by the admin, a burner, or a supply manager.
+    // Reduces the amount in the provided private record and decreases the total token supply in the token metadata.
+    async transition burn_private(
+        input_record: Token,
+        public amount: u128
+    ) -> (Token, Future) {
+        let output_record: Token = Token {
+            owner: input_record.owner,
+            amount: input_record.amount - amount
+        };
+        return (output_record, finalize_burn_private(amount, self.caller));
+    }
+    async function finalize_burn_private(
+        amount: u128,
+        caller: address,
+    ) {
+        let admin_address: address = roles.get_or_use(ADMIN_INDEX, caller);
+        let is_admin: bool = caller == admin_address;
+        if(!is_admin) {
+            let role: u8 = supply_roles.get(caller);
+            assert(role == BURNER_ROLE || role == SUPPLY_MANAGER_ROLE);
+        }
+
+        let token = token_metadata.get(TOKEN_METADATA_INDEX);
+
+        // Update the token supply
+        let new_metadata: TokenMetadata = TokenMetadata {
+            name: token.name,
+            symbol: token.symbol,
+            decimals: token.decimals,
+            supply: token.supply - amount, // underflow will be caught by the VM
+            max_supply: token.max_supply,
+        };
+        token_metadata.set(TOKEN_METADATA_INDEX, new_metadata);
+    }
+
+    // -------------------------
+    // Called by token owners/DeFi contracts
+    // -------------------------
+
+    // Transfers public tokens from the caller to the recipient.
+    // The sender must not be frozen in the freeze list.
+    async transition transfer_public(
+        public recipient: address,
+        public amount: u128
+    ) -> Future {
+        return finalize_transfer_public(recipient, amount, self.caller);
+    }
+    async function finalize_transfer_public(
+        recipient: address,
+        amount: u128,
+        sender: address
+    ) {
+        let is_sender_frozen: bool = freeze_list.get_or_use(sender, false);
+        assert_eq(is_sender_frozen, false);
+
+        let sender_balance = balances.get(sender);
+        balances.set(sender, sender_balance - amount);
+
+        let recipient_balance = balances.get_or_use(recipient, 0u128);
+        balances.set(recipient, recipient_balance + amount);
+    }
+
+    // Transfers public tokens from the signer to the recipient.
+    // The sender must not be frozen in the freeze list.
+    async transition transfer_public_as_signer(
+        public recipient: address,
+        public amount: u128
+    ) -> Future {
+        return f_transfer_public_as_signer(recipient, amount, self.signer);
+    }
+    async function f_transfer_public_as_signer(
+        recipient: address,
+        amount: u128,
+        sender: address
+    ) {
+        let is_sender_frozen: bool = freeze_list.get_or_use(sender, false);
+        assert_eq(is_sender_frozen, false);
+
+        let sender_balance = balances.get(sender);
+        balances.set(sender, sender_balance - amount);
+
+        let recipient_balance = balances.get_or_use(recipient, 0u128);
+        balances.set(recipient, recipient_balance + amount);
+    }
+
+    // Approves a spender to transfer the caller’s public assets up to a specified amount.
+    // Increases the existing allowance if one is already set, otherwise creates a new allowance.
+    // The allowance is stored using a hash of the owner–spender pair as the key.
+    async transition approve_public(
+        public spender: address,
+        public amount: u128
+    ) -> Future {
+        let allowance: Allowance = Allowance {
+            account: self.caller,
+            spender: spender
+        };
+        let allowance_key: field = BHP256::hash_to_field(allowance);
+
+        return finalize_approve_public(amount, allowance_key);
+    }
+    async function finalize_approve_public(
+        amount: u128,
+        allowance_key: field
+    ) {
+        let current_allowance: u128 = allowances.get_or_use(allowance_key, 0u128);
+        // Increase or create the allowance amount
+        allowances.set(allowance_key, current_allowance + amount);
+    }
+
+    // Reduces a spender’s allowance to transfer the caller’s public assets by a specified amount.
+    // Decreases the existing allowance stored under the hash of the owner–spender pair.
+    // If the reduction exceeds the current allowance, the VM will catch the underflow.
+    async transition unapprove_public(
+        public spender: address,
+        public amount: u128
+    ) -> Future {
+        let allowance: Allowance = Allowance {
+            account: self.caller,
+            spender: spender
+        };
+        let allowance_key: field = BHP256::hash_to_field(allowance);
+
+        return finalize_unapprove_public(amount, allowance_key);
+    }
+    async function finalize_unapprove_public(
+        amount: u128,
+        allowance_key: field
+    ) {
+        let current_allowance: u128 = allowances.get(allowance_key);
+        // Decrease the allowance amount
+        allowances.set(allowance_key, current_allowance - amount);
+    }
+
+    // Transfers public tokens from the owner to the recipient.
+    // Can be called by any spender with sufficient allowance from the owner.
+    // Decreases the spender’s allowance by the transferred amount.
+    // The sender must not be frozen in the freeze list.
+    async transition transfer_from_public(
+        public owner: address,
+        public recipient: address,
+        public amount: u128
+    ) -> Future {
+        let allowance: Allowance = Allowance {
+            account: owner,
+            spender: self.caller,
+        };
+        let allowance_key: field = BHP256::hash_to_field(allowance);
+
+        return finalize_transfer_from_public(owner, recipient, amount, allowance_key);
+    }
+    async function finalize_transfer_from_public(
+        sender: address,
+        recipient: address,
+        amount: u128,
+        allowance_key: field
+    ) {
+        let is_sender_frozen: bool = freeze_list.get_or_use(sender, false);
+        assert_eq(is_sender_frozen, false);
+
+        // Check that the spender is authorized to spend the amount
+        let current_allowance: u128 = allowances.get(allowance_key);
+        // Decrease the allowance by the amount being spent
+        allowances.set(allowance_key, current_allowance - amount);
+
+        let sender_balance = balances.get(sender);
+        balances.set(sender, sender_balance - amount);
+
+        let recipient_balance = balances.get_or_use(recipient, 0u128);
+        balances.set(recipient, recipient_balance + amount);
+    }
+
+    // Transfers public tokens from the caller to a recipient as a private token.
+    // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
+    // The sender must not be frozen in the freeze list.
+    async transition transfer_public_to_private(
+        recipient: address,
+        public amount: u128,
+        public investigator_address: address
+    ) -> (ComplianceRecord, Token, Future) {
+        let token: Token = Token {
+            owner: recipient,
+            amount: amount
+        };
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: investigator_address,
+            amount: amount,
+            sender: self.caller,
+            recipient: recipient,
+        };
+
+        return (compliance_record, token, f_transfer_public_to_private(amount, self.caller, investigator_address));
+    }
+    async function f_transfer_public_to_private(
+        amount: u128,
+        sender: address,
+        investigator_address: address
+    ) {
+        let is_sender_frozen: bool = freeze_list.get_or_use(sender, false);
+        assert_eq(is_sender_frozen, false);
+
+        let stored_investigator_address: address = roles.get(INVESTIGATOR_INDEX);
+        assert_eq(stored_investigator_address, investigator_address);
+
+        let sender_balance = balances.get(sender);
+        balances.set(sender, sender_balance - amount);
+    }
+
+    // Transfers public tokens from an owner to a recipient as a private token.
+    // Can be called by any spender with sufficient allowance from the owner.
+    // Decreases the spender’s allowance by the transferred amount.
+    // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
+    // The sender must not be frozen in the freeze list.
+    async transition transfer_from_public_to_private(
+        public owner: address,
+        recipient: address,
+        public amount: u128,
+        public investigator_address: address
+    ) -> (ComplianceRecord, Token, Future) {
+        let token: Token = Token {
+            owner: recipient,
+            amount: amount
+        };
+
+        let allowance: Allowance = Allowance {
+            account: owner,
+            spender: self.caller,
+        };
+        let allowance_key: field = BHP256::hash_to_field(allowance);
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: investigator_address,
+            amount: amount,
+            sender: owner,
+            recipient: recipient,
+        };
+
+        return (compliance_record, token, f_transfer_from_public_to_priv(owner, amount, allowance_key, investigator_address));
+    }
+    async function f_transfer_from_public_to_priv(
+        sender: address,
+        amount: u128,
+        allowance_key: field,
+        investigator_address: address
+    ) {
+        let is_sender_frozen: bool = freeze_list.get_or_use(sender, false);
+        assert_eq(is_sender_frozen, false);
+
+        let stored_investigator_address: address = roles.get(INVESTIGATOR_INDEX);
+        assert_eq(stored_investigator_address, investigator_address);
+
+        // Check that the spender is authorized to spend the amount
+        let current_allowance: u128 = allowances.get(allowance_key);
+        // Decrease the allowance by the amount being spent
+        allowances.set(allowance_key, current_allowance - amount);
+
+        let sender_balance = balances.get(sender);
+        balances.set(sender, sender_balance - amount);
+    }
+
+    // Transfers private tokens from the record owner to a recipient.
+    // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
+    // The sender must not be frozen in the freeze list.
+    // The sender's privacy is preserved by proving non-inclusion in the freeze list Merkle tree.
+    async transition transfer_private(
+        recipient: address,
+        amount: u128,
+        input_record: Token,
+        sender_merkle_proofs: [MerkleProof;2],
+        public investigator_address: address,
+    ) -> (ComplianceRecord, Token, Token, Credentials, Future) {
+        let sender_root: field = verify_non_inclusion(input_record.owner, sender_merkle_proofs);
+
+        let updated_record: Token = Token {
+            owner: input_record.owner,
+            amount: input_record.amount - amount
+        };
+
+        let transfer_record: Token = Token {
+            owner: recipient,
+            amount: amount
+        };
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: investigator_address,
+            amount: amount,
+            sender: input_record.owner,
+            recipient: recipient,
+        };
+
+        let creds_record: Credentials = Credentials {
+            owner: input_record.owner,
+            freeze_list_root: sender_root,
+        };
+
+        return (compliance_record, updated_record, transfer_record, creds_record, f_transfer_private(sender_root, investigator_address));
+    }
+
+    async function f_transfer_private(root: field, investigator_address: address) {
+        let current_root: field = freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+        let window: u32 = block_height_window.get_or_use(BLOCK_HEIGHT_WINDOW_INDEX, 0u32);
+
+        if (current_root != root) {
+            let previous_root: field = freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+            assert_eq(root, previous_root);
+            let updated_height: u32 = root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+            assert(updated_height + window > block.height);
+        }
+
+
+        let stored_investigator_address: address = roles.get(INVESTIGATOR_INDEX);
+        assert_eq(stored_investigator_address, investigator_address);
+    }
+
+    // Transfers private tokens from the record owner to a recipient as a public tokens.
+    // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
+    // The sender must not be frozen in the freeze list.
+    // The sender's privacy is preserved by proving non-inclusion in the freeze list Merkle tree.
+    async transition transfer_private_to_public(
+        public recipient: address,
+        public amount: u128,
+        input_record: Token,
+        sender_merkle_proofs: [MerkleProof; 2],
+        public investigator_address: address
+    ) -> (ComplianceRecord, Token, Credentials, Future) {
+        let root: field = verify_non_inclusion(input_record.owner, sender_merkle_proofs);
+
+        let updated_record: Token = Token {
+            owner: input_record.owner,
+            amount: input_record.amount - amount
+        };
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: investigator_address,
+            amount: amount,
+            sender: input_record.owner,
+            recipient: recipient,
+        };
+
+        let creds_record: Credentials = Credentials {
+            owner: input_record.owner,
+            freeze_list_root: root,
+        };
+
+        return (
+            compliance_record,
+            updated_record,
+            creds_record,
+            f_transfer_private_to_public(
+                root,
+                recipient,
+                amount,
+                investigator_address
+            )
+        );
+    }
+    async function f_transfer_private_to_public(
+        root: field,
+        recipient: address,
+        amount: u128,
+        investigator_address: address
+    ) {
+        let current_root: field = freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+        if (current_root != root) {
+            let previous_root: field = freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+            assert_eq(root, previous_root);
+            let window: u32 = block_height_window.get_or_use(BLOCK_HEIGHT_WINDOW_INDEX, 0u32);
+            let updated_height: u32 = root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+            assert(updated_height + window > block.height);
+        }    
+
+
+        let stored_investigator_address: address = roles.get(INVESTIGATOR_INDEX);
+        assert_eq(stored_investigator_address, investigator_address);
+
+        let recipient_balance = balances.get_or_use(recipient, 0u128);
+        balances.set(recipient, recipient_balance + amount);
+    }
+
+    transition join(
+        private token_1: Token,
+        private token_2: Token
+    ) -> Token {
+        let new_token: Token = Token {
+            owner: token_1.owner,
+            amount: token_1.amount + token_2.amount
+        };
+
+        return new_token;
+    }
+
+    transition split(
+        private token: Token,
+        private amount: u128
+    ) -> (Token, Token) {
+        let new_token_1: Token = Token {
+            owner: token.owner,
+            amount: amount
+        };
+        let new_token_2: Token = Token {
+            owner: token.owner,
+            amount: token.amount - amount
+        };
+
+        return (new_token_1, new_token_2);
+    }
+    // Transfers private tokens from the record owner to a recipient.
+    // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
+    // The sender must not be frozen in the freeze list.
+    // The sender's privacy is preserved by using a Credentials record.
+    async transition transfer_private_with_creds(
+        recipient: address,
+        amount: u128,
+        input_record: Token,
+        creds: Credentials,
+        public investigator_address: address
+    ) -> (ComplianceRecord, Token, Token, Credentials, Future) {
+        let updated_record: Token = Token {
+            owner: input_record.owner,
+            amount: input_record.amount - amount
+        };
+
+        let transfer_record: Token = Token {
+            owner: recipient,
+            amount: amount
+        };
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: investigator_address,
+            amount: amount,
+            sender: input_record.owner,
+            recipient: recipient,
+        };
+
+        let creds_record: Credentials = Credentials {
+            owner: creds.owner,
+            freeze_list_root: creds.freeze_list_root,
+        };
+
+        return (compliance_record, updated_record, transfer_record, creds_record, f_transfer_private_creds(investigator_address, creds.freeze_list_root));
+    }
+    async function f_transfer_private_creds(investigator_address: address, root: field) {
+        let current_root: field = freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+        if (current_root != root) {
+            let previous_root: field = freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+            assert_eq(root, previous_root);
+            let window: u32 = block_height_window.get_or_use(BLOCK_HEIGHT_WINDOW_INDEX, 0u32);
+            let updated_height: u32 = root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+            assert(updated_height + window > block.height);
+        }
+
+        let stored_investigator_address: address = roles.get(INVESTIGATOR_INDEX);
+        assert_eq(stored_investigator_address, investigator_address);
+    }
+
+    // Transfers private tokens from the record owner to a recipient as a public tokens.
+    // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
+    // The sender must not be frozen in the freeze list.
+    // The sender's privacy is preserved by using a Credentials record.
+    async transition transfer_priv_to_public_creds(
+        public recipient: address,
+        public amount: u128,
+        input_record: Token,
+        creds: Credentials,
+        public investigator_address: address
+    ) -> (ComplianceRecord, Token, Credentials, Future) {
+        let updated_record: Token = Token {
+            owner: input_record.owner,
+            amount: input_record.amount - amount
+        };
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: investigator_address,
+            amount: amount,
+            sender: input_record.owner,
+            recipient: recipient,
+        };
+
+        let creds_record: Credentials = Credentials {
+            owner: creds.owner,
+            freeze_list_root: creds.freeze_list_root,
+        };
+
+        return (
+            compliance_record,
+            updated_record,
+            creds_record,
+            f_transfer_priv_to_public_creds(
+                creds.freeze_list_root,
+                recipient,
+                amount,
+                investigator_address
+            )
+        );
+    }
+    async function f_transfer_priv_to_public_creds(
+        root: field,
+        recipient: address,
+        amount: u128,
+        investigator_address: address
+    ) {
+        let current_root: field = freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+        if (current_root != root) {
+            let previous_root: field = freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+            assert_eq(root, previous_root);
+            let window: u32 = block_height_window.get_or_use(BLOCK_HEIGHT_WINDOW_INDEX, 0u32);
+            let updated_height: u32 = root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+            assert(updated_height + window > block.height);
+        }
+
+        let stored_investigator_address: address = roles.get(INVESTIGATOR_INDEX);
+        assert_eq(stored_investigator_address, investigator_address);
+
+        let recipient_balance = balances.get_or_use(recipient, 0u128);
+        balances.set(recipient, recipient_balance + amount);
+    }
+
+    // Calculates the hash of two sibling nodes in a Merkle tree.
+    // The order of the siblings depends on the index bit (0 = left, 1 = right).
+    // Uses Poseidon hash to compute the result.
+    inline calculate_hash_for_neighbor(sibling1: field, sibling2: field, indexbit: u32) -> field {
+        let poseidon_params: [field; 2] = indexbit == 0u32 ? [sibling1, sibling2] : [sibling2, sibling1];
+        return Poseidon4::hash_to_field(poseidon_params);
+    }
+
+    // Calculates the Merkle root and the depth of a Merkle proof path.
+    // Iteratively hashes the sibling path based on the leaf index to reconstruct the root.
+    // Stops when a zero field is encountered in the siblings array, indicating the end of the valid path.
+    // Returns the calculated root and the actual depth reached.
+    inline calculate_root_depth_siblings(merkle_proof: MerkleProof) -> (public field, public u32) {
+        let root: field = calculate_hash_for_neighbor(merkle_proof.siblings[0u8], merkle_proof.siblings[1u8],  merkle_proof.leaf_index % 2u32);
+        for i: u32 in 2u32..MAX_TREE_DEPTH {
+            if (merkle_proof.siblings[i] == 0field) {
+                return (root, i);
+            }
+            root = calculate_hash_for_neighbor(root, merkle_proof.siblings[i], (merkle_proof.leaf_index / (2u32**(i-1u32))) % 2u32);
+        }
+        return (root, MAX_TREE_DEPTH);
+    }
+
+    // Verifies non-inclusion of an address in a Merkle tree sorted in ascending order by address (as field).
+    // Accepts two Merkle proofs representing the neighboring leaves around the missing address.
+    // Returns the common Merkle root if the address is proven to be outside the tree.
+    // If the tree is not sorted correctly, this function may return incorrect results.
+    inline verify_non_inclusion(addr: address, merkle_proofs: [MerkleProof;2]) -> field {
+        let (root1, depth1): (field, u32)= calculate_root_depth_siblings(merkle_proofs[0u32]);
+        let (root2, depth2): (field, u32) = calculate_root_depth_siblings(merkle_proofs[1u32]);
+
+        // Ensure the roots from the merkle proofs are the same
+        assert_eq(root1, root2);
+        
+        let addr_field: field = addr as field;
+        if (merkle_proofs[0u32].leaf_index == merkle_proofs[1u32].leaf_index) {
+            // Ensure that if the address is the most left leaf, it is less than the first sibling
+            if (merkle_proofs[0u32].leaf_index == 0u32) {
+                assert(addr_field < merkle_proofs[0u32].siblings[0u32]);
+            } else {
+                // Ensure that if the address is the most right leaf
+                let last_index_leaf: u32 = 2u32 ** (depth1 - 1u32) - 1u32;
+                assert_eq(merkle_proofs[0u32].leaf_index, last_index_leaf);
+                // Ensure that the address is bigger than the first sibling
+                assert(addr_field > merkle_proofs[0u32].siblings[0u32]);
+            }
+        } else {
+            // Ensure the address is in between the provided leaves
+            assert(addr_field > merkle_proofs[0u32].siblings[0u32]);
+            assert(addr_field < merkle_proofs[1u32].siblings[0u32]);
+            // Ensure the leaves are adjacent
+            assert_eq(merkle_proofs[0u32].leaf_index + 1u32, merkle_proofs[1u32].leaf_index);
+        }
+        
+        return root1;
+    } 
+}

--- a/test/sealed_token.test.ts
+++ b/test/sealed_token.test.ts
@@ -1,0 +1,932 @@
+import { ExecutionMode } from "@doko-js/core";
+
+import { BaseContract } from "../contract/base-contract";
+import { decryptComplianceRecord } from "../artifacts/js/leo2js/sealed_report_policy";
+import { Merkle_treeContract } from "../artifacts/js/merkle_tree";
+import {
+  ADMIN_INDEX,
+  BLOCK_HEIGHT_WINDOW,
+  BLOCK_HEIGHT_WINDOW_INDEX,
+  BURNER_ROLE,
+  CURRENT_FREEZE_LIST_ROOT_INDEX,
+  FREEZE_LIST_LAST_INDEX,
+  FREEZE_LIST_MANAGER_INDEX,
+  INVESTIGATOR_INDEX,
+  TREE_DEPTH_12,
+  MINTER_ROLE,
+  NONE_ROLE,
+  PREVIOUS_FREEZE_LIST_ROOT_INDEX,
+  SUPPLY_MANAGER_ROLE,
+  ZERO_ADDRESS,
+  emptyRoot,
+  fundedAmount,
+} from "../lib/Constants";
+import { getLeafIndices, getSiblingPath } from "../lib/FreezeList";
+import { fundWithCredits } from "../lib/Fund";
+import { deployIfNotDeployed } from "../lib/Deploy";
+import { buildTree, genLeaves } from "../lib/MerkleTree";
+import { Account } from "@provablehq/sdk";
+import { stringToBigInt } from "../lib/Conversion";
+import { decryptToken } from "../artifacts/js/leo2js/sealed_report_token";
+import { Token } from "../artifacts/js/types/sealed_report_token";
+import { Sealed_stable_tokenContract } from "../artifacts/js/sealed_stable_token";
+import { Credentials } from "../artifacts/js/types/sealed_stable_token";
+import { decryptCredentials } from "../artifacts/js/leo2js/sealed_stable_token";
+
+const mode = ExecutionMode.SnarkExecute;
+const contract = new BaseContract({ mode });
+
+// This maps the accounts defined inside networks in aleo-config.js and return array of address of respective private keys
+// THE ORDER IS IMPORTANT, IT MUST MATCH THE ORDER IN THE NETWORKS CONFIG
+const [
+  deployerAddress,
+  adminAddress,
+  investigatorAddress,
+  frozenAccount,
+  account,
+  recipient,
+  minter,
+  burner,
+  supplyManager,
+  spender,
+  freezeListManager,
+] = contract.getAccounts();
+const deployerPrivKey = contract.getPrivateKey(deployerAddress);
+const investigatorPrivKey = contract.getPrivateKey(investigatorAddress);
+const frozenAccountPrivKey = contract.getPrivateKey(frozenAccount);
+const adminPrivKey = contract.getPrivateKey(adminAddress);
+const accountPrivKey = contract.getPrivateKey(account);
+const recipientPrivKey = contract.getPrivateKey(recipient);
+const minterPrivKey = contract.getPrivateKey(minter);
+const burnerPrivKey = contract.getPrivateKey(burner);
+const supplyManagerPrivKey = contract.getPrivateKey(supplyManager);
+const spenderPrivKey = contract.getPrivateKey(spender);
+const freezeListManagerPrivKey = contract.getPrivateKey(freezeListManager);
+
+const stableTokenContract = new Sealed_stable_tokenContract({
+  mode,
+  privateKey: deployerPrivKey,
+});
+const stableTokenContractForAdmin = new Sealed_stable_tokenContract({
+  mode,
+  privateKey: adminPrivKey,
+});
+const stableTokenContractForFreezeListManager = new Sealed_stable_tokenContract({
+  mode,
+  privateKey: freezeListManagerPrivKey,
+});
+const stableTokenContractForAccount = new Sealed_stable_tokenContract({
+  mode,
+  privateKey: accountPrivKey,
+});
+const stableTokenContractForMinter = new Sealed_stable_tokenContract({
+  mode,
+  privateKey: minterPrivKey,
+});
+const stableTokenContractForBurner = new Sealed_stable_tokenContract({
+  mode,
+  privateKey: burnerPrivKey,
+});
+const stableTokenContractForSupplyManager = new Sealed_stable_tokenContract({
+  mode,
+  privateKey: supplyManagerPrivKey,
+});
+const stableTokenContractForSpender = new Sealed_stable_tokenContract({
+  mode,
+  privateKey: spenderPrivKey,
+});
+const stableTokenContractForFrozenAccount = new Sealed_stable_tokenContract({
+  mode,
+  privateKey: frozenAccountPrivKey,
+});
+const merkleTreeContract = new Merkle_treeContract({
+  mode,
+  privateKey: deployerPrivKey,
+});
+
+const amount = 10n;
+let root: bigint;
+
+describe("test sealed_report_token program", () => {
+  beforeAll(async () => {
+    await fundWithCredits(deployerPrivKey, adminAddress, fundedAmount);
+    await fundWithCredits(deployerPrivKey, frozenAccount, fundedAmount);
+    await fundWithCredits(deployerPrivKey, account, fundedAmount);
+    await fundWithCredits(deployerPrivKey, freezeListManager, fundedAmount);
+
+    await fundWithCredits(deployerPrivKey, minter, fundedAmount);
+    await fundWithCredits(deployerPrivKey, supplyManager, fundedAmount);
+    await fundWithCredits(deployerPrivKey, burner, fundedAmount);
+    await fundWithCredits(deployerPrivKey, spender, fundedAmount);
+
+    await deployIfNotDeployed(merkleTreeContract);
+    await deployIfNotDeployed(stableTokenContract);
+  });
+
+  test(`test update_admin_address`, async () => {
+    let tx = await stableTokenContractForAdmin.update_role(frozenAccount, ADMIN_INDEX);
+    await tx.wait();
+    let adminRole = await stableTokenContract.roles(ADMIN_INDEX);
+    expect(adminRole).toBe(frozenAccount);
+
+    tx = await stableTokenContractForFrozenAccount.update_role(adminAddress, ADMIN_INDEX);
+    await tx.wait();
+    adminRole = await stableTokenContract.roles(ADMIN_INDEX);
+    expect(adminRole).toBe(adminAddress);
+
+    tx = await stableTokenContractForFrozenAccount.update_role(frozenAccount, ADMIN_INDEX);
+    await expect(tx.wait()).rejects.toThrow();
+  });
+
+  test(`test update_investigator_address`, async () => {
+    let tx = await stableTokenContractForAdmin.update_role(frozenAccount, INVESTIGATOR_INDEX);
+    await tx.wait();
+    let investigatorRole = await stableTokenContract.roles(INVESTIGATOR_INDEX);
+    expect(investigatorRole).toBe(frozenAccount);
+
+    tx = await stableTokenContractForAdmin.update_role(investigatorAddress, INVESTIGATOR_INDEX);
+    await tx.wait();
+    investigatorRole = await stableTokenContract.roles(INVESTIGATOR_INDEX);
+    expect(investigatorRole).toBe(investigatorAddress);
+
+    const rejectedTx = await stableTokenContractForFrozenAccount.update_role(frozenAccount, INVESTIGATOR_INDEX);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+  });
+
+  test(`test update_freeze_list_manager`, async () => {
+    let tx = await stableTokenContractForAdmin.update_role(freezeListManager, FREEZE_LIST_MANAGER_INDEX);
+    await tx.wait();
+    const freezeListManagerRole = await stableTokenContract.roles(FREEZE_LIST_MANAGER_INDEX);
+    expect(freezeListManagerRole).toBe(freezeListManager);
+
+    tx = await stableTokenContractForFrozenAccount.update_role(frozenAccount, FREEZE_LIST_MANAGER_INDEX);
+    await expect(tx.wait()).rejects.toThrow();
+  });
+
+  let senderMerkleProof: { siblings: any[]; leaf_index: any }[];
+  let frozenAccountMerkleProof: { siblings: any[]; leaf_index: any }[];
+  test(`generate merkle proofs`, async () => {
+    const leaves = genLeaves([frozenAccount]);
+    const tree = buildTree(leaves);
+    root = tree[tree.length - 1];
+    const senderLeafIndices = getLeafIndices(tree, account);
+    const recipientLeafIndices = getLeafIndices(tree, recipient);
+    const frozenAccountLeafIndices = getLeafIndices(tree, frozenAccount);
+    senderMerkleProof = [
+      getSiblingPath(tree, senderLeafIndices[0], TREE_DEPTH_12),
+      getSiblingPath(tree, senderLeafIndices[1], TREE_DEPTH_12),
+    ];
+    frozenAccountMerkleProof = [
+      getSiblingPath(tree, frozenAccountLeafIndices[0], TREE_DEPTH_12),
+      getSiblingPath(tree, frozenAccountLeafIndices[1], TREE_DEPTH_12),
+    ];
+  });
+
+  test(`test initialize`, async () => {
+    // Cannot update freeze list before initialization
+    let rejectedTx = await stableTokenContractForAdmin.update_freeze_list(frozenAccount, true, 1, 0n, root);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+    const name = stringToBigInt("Report Token");
+    const symbol = stringToBigInt("REPORT_TOKEN");
+    const decimals = 6;
+    const maxSupply = 1000_000000000000n;
+
+    const tx = await stableTokenContract.initialize(name, symbol, decimals, maxSupply, BLOCK_HEIGHT_WINDOW);
+    await tx.wait();
+
+    const isAccountFrozen = await stableTokenContract.freeze_list(ZERO_ADDRESS);
+    const frozenAccountByIndex = await stableTokenContract.freeze_list_index(0);
+    const lastIndex = await stableTokenContract.freeze_list_last_index(FREEZE_LIST_LAST_INDEX);
+    const initializedRoot = await stableTokenContract.freeze_list_root(CURRENT_FREEZE_LIST_ROOT_INDEX);
+    const blockHeightWindow = await stableTokenContract.block_height_window(BLOCK_HEIGHT_WINDOW_INDEX);
+
+    expect(isAccountFrozen).toBe(false);
+    expect(frozenAccountByIndex).toBe(ZERO_ADDRESS);
+    expect(lastIndex).toBe(0);
+    expect(initializedRoot).toBe(emptyRoot);
+    expect(blockHeightWindow).toBe(BLOCK_HEIGHT_WINDOW);
+
+    // It is possible to call to initialize only one time
+    rejectedTx = await stableTokenContract.initialize(name, symbol, decimals, maxSupply, BLOCK_HEIGHT_WINDOW);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+  });
+
+  test(`test update_supply_role`, async () => {
+    // Non admin user cannot update minter role
+    let rejectedTx = await stableTokenContractForAccount.update_supply_role(minter, MINTER_ROLE);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+    // Non admin user cannot update burner role
+    rejectedTx = await stableTokenContractForAccount.update_supply_role(burner, BURNER_ROLE);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+    // Non admin user cannot update supply manager role
+    rejectedTx = await stableTokenContractForAccount.update_supply_role(supplyManager, SUPPLY_MANAGER_ROLE);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+    // Non admin user cannot update none role
+    rejectedTx = await stableTokenContractForAccount.update_supply_role(account, SUPPLY_MANAGER_ROLE);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    let tx = await stableTokenContractForAdmin.update_supply_role(minter, MINTER_ROLE);
+    await tx.wait();
+    let role = await stableTokenContract.supply_roles(minter);
+    expect(role).toBe(MINTER_ROLE);
+
+    tx = await stableTokenContractForAdmin.update_supply_role(burner, BURNER_ROLE);
+    await tx.wait();
+    role = await stableTokenContract.supply_roles(burner);
+    expect(role).toBe(BURNER_ROLE);
+
+    tx = await stableTokenContractForAdmin.update_supply_role(supplyManager, SUPPLY_MANAGER_ROLE);
+    await tx.wait();
+    role = await stableTokenContract.supply_roles(supplyManager);
+    expect(role).toBe(SUPPLY_MANAGER_ROLE);
+
+    tx = await stableTokenContractForAdmin.update_supply_role(account, NONE_ROLE);
+    await tx.wait();
+    role = await stableTokenContract.supply_roles(account);
+    expect(role).toBe(NONE_ROLE);
+  });
+
+  let accountRecord: Token;
+  let frozenAccountRecord: Token;
+  test(`test mint_private`, async () => {
+    // a regular user cannot mint private assets
+    let rejectedTx = await stableTokenContractForAccount.mint_private(account, amount * 20n);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+    // a burner cannot mint private assets
+    rejectedTx = await stableTokenContractForBurner.mint_private(account, amount * 20n);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    let tx = await stableTokenContractForAdmin.mint_private(account, amount * 20n);
+    const [encryptedAccountRecord] = await tx.wait();
+    accountRecord = decryptToken(encryptedAccountRecord, accountPrivKey);
+    expect(accountRecord.amount).toBe(amount * 20n);
+    expect(accountRecord.owner).toBe(account);
+
+    tx = await stableTokenContractForMinter.mint_private(frozenAccount, amount * 20n);
+    const [encryptedFrozenAccountRecord] = await tx.wait();
+    frozenAccountRecord = decryptToken(encryptedFrozenAccountRecord, frozenAccountPrivKey);
+    expect(frozenAccountRecord.amount).toBe(amount * 20n);
+    expect(frozenAccountRecord.owner).toBe(frozenAccount);
+
+    tx = await stableTokenContractForSupplyManager.mint_private(account, amount * 20n);
+    await tx.wait();
+  });
+
+  test(`test mint_public`, async () => {
+    // a regular user cannot mint public assets
+    let rejectedTx = await stableTokenContractForAccount.mint_public(account, amount * 20n);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+    // a burner cannot mint public assets
+    rejectedTx = await stableTokenContractForBurner.mint_public(account, amount * 20n);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    let tx = await stableTokenContractForAdmin.mint_public(account, amount * 20n);
+    await tx.wait();
+    let balance = await stableTokenContract.balances(account);
+    expect(balance).toBe(amount * 20n);
+
+    tx = await stableTokenContractForMinter.mint_public(frozenAccount, amount * 20n);
+    await tx.wait();
+    balance = await stableTokenContract.balances(frozenAccount);
+    expect(balance).toBe(amount * 20n);
+
+    tx = await stableTokenContractForSupplyManager.mint_public(account, amount * 20n);
+    await tx.wait();
+    balance = await stableTokenContract.balances(account);
+    expect(balance).toBe(amount * 40n);
+  });
+
+  test(`test burn_private`, async () => {
+    // A user that is not burner, supply manager, or admin  cannot burn private assets
+    let rejectedTx = await stableTokenContractForAccount.burn_private(accountRecord, amount);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    let mintTx = await stableTokenContractForAdmin.mint_private(adminAddress, amount);
+    let [encryptedAdminRecord] = await mintTx.wait();
+    let adminRecord = decryptToken(encryptedAdminRecord, adminPrivKey);
+    expect(adminRecord.amount).toBe(amount);
+    expect(adminRecord.owner).toBe(adminAddress);
+    let burnTx = await stableTokenContractForAdmin.burn_private(adminRecord, amount);
+    [encryptedAdminRecord] = await burnTx.wait();
+    adminRecord = decryptToken(encryptedAdminRecord, adminPrivKey);
+    expect(adminRecord.amount).toBe(0n);
+    expect(adminRecord.owner).toBe(adminAddress);
+
+    mintTx = await stableTokenContractForAdmin.mint_private(burner, amount);
+    let [encryptedBurnerRecord] = await mintTx.wait();
+    let burnerRecord = decryptToken(encryptedBurnerRecord, burnerPrivKey);
+    expect(burnerRecord.amount).toBe(amount);
+    expect(burnerRecord.owner).toBe(burner);
+    burnTx = await stableTokenContractForBurner.burn_private(burnerRecord, amount);
+    [encryptedBurnerRecord] = await burnTx.wait();
+    burnerRecord = decryptToken(encryptedBurnerRecord, burnerPrivKey);
+    expect(burnerRecord.amount).toBe(0n);
+    expect(burnerRecord.owner).toBe(burner);
+
+    mintTx = await stableTokenContractForAdmin.mint_private(supplyManager, amount);
+    let [encryptedSupplyManager] = await mintTx.wait();
+    let supplyManagerRecord = decryptToken(encryptedSupplyManager, supplyManagerPrivKey);
+    expect(supplyManagerRecord.amount).toBe(amount);
+    expect(supplyManagerRecord.owner).toBe(supplyManager);
+    burnTx = await stableTokenContractForSupplyManager.burn_private(supplyManagerRecord, amount);
+    [encryptedSupplyManager] = await burnTx.wait();
+    supplyManagerRecord = decryptToken(encryptedSupplyManager, supplyManagerPrivKey);
+    expect(supplyManagerRecord.amount).toBe(0n);
+    expect(supplyManagerRecord.owner).toBe(supplyManager);
+  });
+
+  test(`test burn_public`, async () => {
+    // A regular user cannot burn public assets
+    let rejectedTx = await stableTokenContractForAccount.burn_public(account, amount);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    // A minter user cannot burn public assets
+    rejectedTx = await stableTokenContractForMinter.burn_public(account, amount);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    const previousAccountPublicBalance = await stableTokenContract.balances(account);
+    let tx = await stableTokenContractForAdmin.burn_public(account, amount);
+    await tx.wait();
+    let balance = await stableTokenContract.balances(account);
+    expect(balance).toBe(previousAccountPublicBalance - amount);
+
+    tx = await stableTokenContractForBurner.burn_public(account, amount);
+    await tx.wait();
+    balance = await stableTokenContract.balances(account);
+    expect(balance).toBe(previousAccountPublicBalance - amount * 2n);
+
+    tx = await stableTokenContractForSupplyManager.burn_public(account, amount);
+    await tx.wait();
+    balance = await stableTokenContract.balances(account);
+    expect(balance).toBe(previousAccountPublicBalance - amount * 3n);
+  });
+
+  test(`test update_freeze_list`, async () => {
+    const currentRoot = await stableTokenContract.freeze_list_root(CURRENT_FREEZE_LIST_ROOT_INDEX);
+
+    // Only the admin can call to update_freeze_list
+    let rejectedTx = await stableTokenContractForFrozenAccount.update_freeze_list(
+      adminAddress,
+      true,
+      1,
+      currentRoot,
+      root,
+    );
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    // Cannot unfreeze an unfrozen account
+    rejectedTx = await stableTokenContractForAdmin.update_freeze_list(frozenAccount, false, 1, currentRoot, root);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    // Cannot update the root if the previous root is incorrect
+    rejectedTx = await stableTokenContractForAdmin.update_freeze_list(frozenAccount, false, 1, 0n, root);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    let tx = await stableTokenContractForAdmin.update_freeze_list(frozenAccount, true, 1, currentRoot, root);
+    await tx.wait();
+    let isAccountFrozen = await stableTokenContract.freeze_list(frozenAccount);
+    let frozenAccountByIndex = await stableTokenContract.freeze_list_index(1);
+    let lastIndex = await stableTokenContract.freeze_list_last_index(FREEZE_LIST_LAST_INDEX);
+
+    expect(isAccountFrozen).toBe(true);
+    expect(frozenAccountByIndex).toBe(frozenAccount);
+    expect(lastIndex).toBe(1);
+
+    // Cannot unfreeze an account when the freezed list index is incorrect
+    rejectedTx = await stableTokenContractForAdmin.update_freeze_list(frozenAccount, false, 2, root, root);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    // Cannot freeze a frozen account
+    rejectedTx = await stableTokenContractForAdmin.update_freeze_list(frozenAccount, true, 1, root, root);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    tx = await stableTokenContractForAdmin.update_freeze_list(frozenAccount, false, 1, root, root);
+    await tx.wait();
+    isAccountFrozen = await stableTokenContract.freeze_list(frozenAccount);
+    frozenAccountByIndex = await stableTokenContract.freeze_list_index(1);
+    lastIndex = await stableTokenContract.freeze_list_last_index(FREEZE_LIST_LAST_INDEX);
+
+    expect(isAccountFrozen).toBe(false);
+    expect(frozenAccountByIndex).toBe(ZERO_ADDRESS);
+    expect(lastIndex).toBe(1);
+
+    tx = await stableTokenContractForFreezeListManager.update_freeze_list(frozenAccount, true, 1, root, root);
+    await tx.wait();
+    isAccountFrozen = await stableTokenContract.freeze_list(frozenAccount);
+    frozenAccountByIndex = await stableTokenContract.freeze_list_index(1);
+    lastIndex = await stableTokenContract.freeze_list_last_index(FREEZE_LIST_LAST_INDEX);
+
+    expect(isAccountFrozen).toBe(true);
+    expect(frozenAccountByIndex).toBe(frozenAccount);
+    expect(lastIndex).toBe(1);
+
+    let randomAddress = new Account().address().to_string();
+    tx = await stableTokenContractForAdmin.update_freeze_list(randomAddress, true, 2, root, root);
+    await tx.wait();
+    isAccountFrozen = await stableTokenContractForAdmin.freeze_list(randomAddress);
+    frozenAccountByIndex = await stableTokenContractForAdmin.freeze_list_index(2);
+    lastIndex = await stableTokenContractForAdmin.freeze_list_last_index(FREEZE_LIST_LAST_INDEX);
+
+    expect(isAccountFrozen).toBe(true);
+    expect(frozenAccountByIndex).toBe(randomAddress);
+    expect(lastIndex).toBe(2);
+
+    randomAddress = new Account().address().to_string();
+    // Cannot freeze an account when the freezed list index is greater than the last index
+    rejectedTx = await stableTokenContractForAdmin.update_freeze_list(randomAddress, true, 10, root, root);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    // Cannot freeze an account when the freezed list index is already taken
+    rejectedTx = await stableTokenContractForAdmin.update_freeze_list(randomAddress, true, 2, root, root);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+  });
+
+  test(`test update_block_height_window`, async () => {
+    const rejectedTx = await stableTokenContractForAccount.update_block_height_window(BLOCK_HEIGHT_WINDOW);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    const tx = await stableTokenContractForAdmin.update_block_height_window(BLOCK_HEIGHT_WINDOW);
+    await tx.wait();
+  });
+
+  test(`test transfer_public`, async () => {
+    // If the sender is frozen account it's impossible to send tokens
+    let rejectedTx = await stableTokenContractForFrozenAccount.transfer_public(recipient, amount);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    const previousAccountPublicBalance = await stableTokenContract.balances(account);
+    const previousRecipientPublicBalance = await stableTokenContract.balances(recipient, 0n);
+
+    const tx = await stableTokenContractForAccount.transfer_public(recipient, amount);
+    await tx.wait();
+
+    const accountPublicBalance = await stableTokenContract.balances(account);
+    const recipientPublicBalance = await stableTokenContract.balances(recipient);
+    expect(accountPublicBalance).toBe(previousAccountPublicBalance - amount);
+    expect(recipientPublicBalance).toBe(previousRecipientPublicBalance + amount);
+  });
+
+  test(`test transfer_public_as_signer`, async () => {
+    // If the sender is frozen account it's impossible to send tokens
+    let rejectedTx = await stableTokenContractForFrozenAccount.transfer_public_as_signer(recipient, amount);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    const previousAccountPublicBalance = await stableTokenContract.balances(account);
+    const previousRecipientPublicBalance = await stableTokenContract.balances(recipient, 0n);
+
+    const tx = await stableTokenContractForAccount.transfer_public_as_signer(recipient, amount);
+    await tx.wait();
+
+    const accountPublicBalance = await stableTokenContract.balances(account);
+    const recipientPublicBalance = await stableTokenContract.balances(recipient);
+    expect(accountPublicBalance).toBe(previousAccountPublicBalance - amount);
+    expect(recipientPublicBalance).toBe(previousRecipientPublicBalance + amount);
+  });
+
+  test(`test transfer_from_public`, async () => {
+    // If the sender didn't approve the spender the transaction will fail
+    let rejectedTx = await stableTokenContractForSpender.transfer_from_public(account, recipient, amount);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    let approveTx = await stableTokenContractForAccount.approve_public(spender, amount);
+    await approveTx.wait();
+    let unapproveTx = await stableTokenContractForAccount.unapprove_public(spender, amount);
+    await unapproveTx.wait();
+
+    // If the sender approve and then unapprove the spender the transaction will fail
+    rejectedTx = await stableTokenContractForSpender.transfer_from_public(account, recipient, amount);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    // approve the spender
+    approveTx = await stableTokenContractForAccount.approve_public(spender, amount);
+    await approveTx.wait();
+    approveTx = await stableTokenContractForFrozenAccount.approve_public(spender, amount);
+    await approveTx.wait();
+
+    // If the sender is frozen account it's impossible to send tokens
+    rejectedTx = await stableTokenContractForSpender.transfer_from_public(frozenAccount, recipient, amount);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    const previousAccountPublicBalance = await stableTokenContract.balances(account);
+    const previousRecipientPublicBalance = await stableTokenContract.balances(recipient, 0n);
+
+    const tx = await stableTokenContractForSpender.transfer_from_public(account, recipient, amount);
+    await tx.wait();
+
+    const accountPublicBalance = await stableTokenContract.balances(account);
+    const recipientPublicBalance = await stableTokenContract.balances(recipient);
+    expect(accountPublicBalance).toBe(previousAccountPublicBalance - amount);
+    expect(recipientPublicBalance).toBe(previousRecipientPublicBalance + amount);
+  });
+
+  test(`test transfer_from_public_to_private`, async () => {
+    // If the sender didn't approve the spender the transaction will fail
+    let rejectedTx = await stableTokenContractForSpender.transfer_from_public_to_private(
+      account,
+      recipient,
+      amount,
+      investigatorAddress,
+    );
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    let approveTx = await stableTokenContractForAccount.approve_public(spender, amount);
+    await approveTx.wait();
+    let unapproveTx = await stableTokenContractForAccount.unapprove_public(spender, amount);
+    await unapproveTx.wait();
+
+    // If the sender approve and then unapprove the spender the transaction will fail
+    rejectedTx = await stableTokenContractForSpender.transfer_from_public_to_private(
+      account,
+      recipient,
+      amount,
+      investigatorAddress,
+    );
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    // approve the spender
+    approveTx = await stableTokenContractForAccount.approve_public(spender, amount);
+    await approveTx.wait();
+    approveTx = await stableTokenContractForFrozenAccount.approve_public(spender, amount);
+    await approveTx.wait();
+
+    // If the sender is frozen account it's impossible to send tokens
+    rejectedTx = await stableTokenContractForSpender.transfer_from_public_to_private(
+      frozenAccount,
+      recipient,
+      amount,
+      investigatorAddress,
+    );
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    // If the investigator address is wrong it's impossible to send tokens
+    rejectedTx = await stableTokenContractForSpender.transfer_from_public_to_private(
+      account,
+      recipient,
+      amount,
+      ZERO_ADDRESS,
+    );
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    const previousAccountPublicBalance = await stableTokenContract.balances(account);
+
+    const tx = await stableTokenContractForSpender.transfer_from_public_to_private(
+      account,
+      recipient,
+      amount,
+      investigatorAddress,
+    );
+    const [complianceRecord, encryptedRecipientRecord] = await tx.wait();
+    const recipientRecord = decryptToken(encryptedRecipientRecord, recipientPrivKey);
+    expect(recipientRecord.owner).toBe(recipient);
+    expect(recipientRecord.amount).toBe(amount);
+
+    const decryptedComplianceRecord = decryptComplianceRecord(complianceRecord, investigatorPrivKey);
+    expect(decryptedComplianceRecord.owner).toBe(investigatorAddress);
+    expect(decryptedComplianceRecord.amount).toBe(amount);
+    expect(decryptedComplianceRecord.sender).toBe(account);
+    expect(decryptedComplianceRecord.recipient).toBe(recipient);
+
+    const accountPublicBalance = await stableTokenContract.balances(account);
+    expect(accountPublicBalance).toBe(previousAccountPublicBalance - amount);
+  });
+
+  test(`test transfer_public_to_priv`, async () => {
+    // If the sender is frozen account it's impossible to send tokens
+    let rejectedTx = await stableTokenContractForFrozenAccount.transfer_public_to_private(
+      recipient,
+      amount,
+      investigatorAddress,
+    );
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    // If the investigator address is wrong it's impossible to send tokens
+    rejectedTx = await stableTokenContractForAccount.transfer_public_to_private(recipient, amount, ZERO_ADDRESS);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    const previousAccountPublicBalance = await stableTokenContract.balances(account);
+
+    const tx = await stableTokenContractForAccount.transfer_public_to_private(recipient, amount, investigatorAddress);
+    const [complianceRecord, tokenRecord] = await tx.wait();
+    const recipientRecord = decryptToken(tokenRecord, recipientPrivKey);
+    expect(recipientRecord.owner).toBe(recipient);
+    expect(recipientRecord.amount).toBe(amount);
+
+    const decryptedComplianceRecord = decryptComplianceRecord(complianceRecord, investigatorPrivKey);
+    expect(decryptedComplianceRecord.owner).toBe(investigatorAddress);
+    expect(decryptedComplianceRecord.amount).toBe(amount);
+    expect(decryptedComplianceRecord.sender).toBe(account);
+    expect(decryptedComplianceRecord.recipient).toBe(recipient);
+
+    const accountPublicBalance = await stableTokenContract.balances(account);
+    expect(accountPublicBalance).toBe(previousAccountPublicBalance - amount);
+  });
+
+  test(`test transfer_private`, async () => {
+    // If the sender is frozen account it's impossible to send tokens
+    await expect(
+      stableTokenContractForFrozenAccount.transfer_private(
+        recipient,
+        amount,
+        accountRecord,
+        frozenAccountMerkleProof,
+        investigatorAddress,
+      ),
+    ).rejects.toThrow();
+
+    // If the investigator address is wrong it's impossible to send tokens
+    const rejectedTx = await stableTokenContractForAccount.transfer_private(
+      recipient,
+      amount,
+      accountRecord,
+      senderMerkleProof,
+      ZERO_ADDRESS,
+    );
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    const tx = await stableTokenContractForAccount.transfer_private(
+      recipient,
+      amount,
+      accountRecord,
+      senderMerkleProof,
+      investigatorAddress,
+    );
+    const [complianceRecord, encryptedSenderRecord, encryptedRecipientRecord] = await tx.wait();
+
+    const previousAmount = accountRecord.amount;
+    accountRecord = decryptToken(encryptedSenderRecord, accountPrivKey);
+    const recipientRecord = decryptToken(encryptedRecipientRecord, recipientPrivKey);
+    expect(accountRecord.owner).toBe(account);
+    expect(accountRecord.amount).toBe(previousAmount - amount);
+    expect(recipientRecord.owner).toBe(recipient);
+    expect(recipientRecord.amount).toBe(amount);
+
+    const decryptedComplianceRecord = decryptComplianceRecord(complianceRecord, investigatorPrivKey);
+    expect(decryptedComplianceRecord.owner).toBe(investigatorAddress);
+    expect(decryptedComplianceRecord.amount).toBe(amount);
+    expect(decryptedComplianceRecord.sender).toBe(account);
+    expect(decryptedComplianceRecord.recipient).toBe(recipient);
+  });
+
+  test(`test transfer_priv_to_public`, async () => {
+    // If the sender is frozen account it's impossible to send tokens
+    await expect(
+      stableTokenContractForFrozenAccount.transfer_private_to_public(
+        recipient,
+        amount,
+        frozenAccountRecord,
+        frozenAccountMerkleProof,
+        investigatorAddress,
+      ),
+    ).rejects.toThrow();
+
+    // If the investigator address is wrong it's impossible to send tokens
+    const rejectedTx = await stableTokenContractForAccount.transfer_private_to_public(
+      recipient,
+      amount,
+      accountRecord,
+      senderMerkleProof,
+      ZERO_ADDRESS,
+    );
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    const previousRecipientPublicBalance = await stableTokenContract.balances(recipient, 0n);
+
+    const tx = await stableTokenContractForAccount.transfer_private_to_public(
+      recipient,
+      amount,
+      accountRecord,
+      senderMerkleProof,
+      investigatorAddress,
+    );
+    const [complianceRecord, encryptedAccountRecord] = await tx.wait();
+
+    const previousAmount = accountRecord.amount;
+    accountRecord = decryptToken(encryptedAccountRecord, accountPrivKey);
+    expect(accountRecord.owner).toBe(account);
+    expect(accountRecord.amount).toBe(previousAmount - amount);
+
+    const decryptedComplianceRecord = decryptComplianceRecord(complianceRecord, investigatorPrivKey);
+    expect(decryptedComplianceRecord.owner).toBe(investigatorAddress);
+    expect(decryptedComplianceRecord.amount).toBe(amount);
+    expect(decryptedComplianceRecord.sender).toBe(account);
+    expect(decryptedComplianceRecord.recipient).toBe(recipient);
+
+    const recipientPublicBalance = await stableTokenContract.balances(recipient);
+    expect(recipientPublicBalance).toBe(previousRecipientPublicBalance + amount);
+  });
+
+  let creds: Credentials;
+  test(`test get_credentials`, async () => {
+    // It's impossible to get the credentials record with an invalid merkle proof
+    await expect(stableTokenContractForFrozenAccount.get_credentials(frozenAccountMerkleProof)).rejects.toThrow();
+
+    const randomAddress = new Account().address().to_string();
+    const leaves = genLeaves([randomAddress]);
+    const tree = buildTree(leaves);
+    const senderLeafIndices = getLeafIndices(tree, account);
+    const IncorrectSenderMerkleProof = [
+      getSiblingPath(tree, senderLeafIndices[0], TREE_DEPTH_12),
+      getSiblingPath(tree, senderLeafIndices[1], TREE_DEPTH_12),
+    ];
+
+    // If the root doesn't match the on-chain root the transaction will be rejected
+    const rejectedTx = await stableTokenContractForAccount.get_credentials(IncorrectSenderMerkleProof);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    const tx = await stableTokenContractForAccount.get_credentials(senderMerkleProof);
+    const [decryptedCreds] = await tx.wait();
+    creds = await decryptCredentials(decryptedCreds, accountPrivKey);
+    expect(creds.owner).toBe(account);
+    expect(creds.freeze_list_root).toBe(root);
+  });
+
+  test(`test transfer with creds`, async () => {
+    let transferPrivateTx = await stableTokenContractForAccount.transfer_private_with_creds(
+      recipient,
+      amount,
+      accountRecord,
+      creds,
+      investigatorAddress,
+    );
+    let [complianceRecord, encryptedSenderRecord, encryptedRecipientRecord, encryptedCredRecord] =
+      await transferPrivateTx.wait();
+    creds = await decryptCredentials(encryptedCredRecord, accountPrivKey);
+    expect(creds.owner).toBe(account);
+    expect(creds.freeze_list_root).toBe(root);
+    let previousAmount = accountRecord.amount;
+    accountRecord = decryptToken(encryptedSenderRecord, accountPrivKey);
+    let recipientRecord = decryptToken(encryptedRecipientRecord, recipientPrivKey);
+    expect(accountRecord.owner).toBe(account);
+    expect(accountRecord.amount).toBe(previousAmount - amount);
+    expect(recipientRecord.owner).toBe(recipient);
+    expect(recipientRecord.amount).toBe(amount);
+
+    let decryptedComplianceRecord = decryptComplianceRecord(complianceRecord, investigatorPrivKey);
+    expect(decryptedComplianceRecord.owner).toBe(investigatorAddress);
+    expect(decryptedComplianceRecord.amount).toBe(amount);
+    expect(decryptedComplianceRecord.sender).toBe(account);
+    expect(decryptedComplianceRecord.recipient).toBe(recipient);
+
+    let transferPrivToPublicTx = await stableTokenContractForAccount.transfer_priv_to_public_creds(
+      recipient,
+      amount,
+      accountRecord,
+      creds,
+      investigatorAddress,
+    );
+    [complianceRecord, encryptedSenderRecord, encryptedCredRecord] = await transferPrivToPublicTx.wait();
+    creds = await decryptCredentials(encryptedCredRecord, accountPrivKey);
+    expect(creds.owner).toBe(account);
+    expect(creds.freeze_list_root).toBe(root);
+    previousAmount = accountRecord.amount;
+    accountRecord = decryptToken(encryptedSenderRecord, accountPrivKey);
+    expect(accountRecord.owner).toBe(account);
+    expect(accountRecord.amount).toBe(previousAmount - amount);
+
+    decryptedComplianceRecord = decryptComplianceRecord(complianceRecord, investigatorPrivKey);
+    expect(decryptedComplianceRecord.owner).toBe(investigatorAddress);
+    expect(decryptedComplianceRecord.amount).toBe(amount);
+    expect(decryptedComplianceRecord.sender).toBe(account);
+    expect(decryptedComplianceRecord.recipient).toBe(recipient);
+
+    // Update the root to make the old creds expired
+    let updateFreezeListTx = await stableTokenContractForAdmin.update_freeze_list(
+      frozenAccount,
+      false,
+      1,
+      root,
+      1n, // fake root
+    );
+    await updateFreezeListTx.wait();
+    let updateBlockHeightWindowTx = await stableTokenContractForAdmin.update_block_height_window(1);
+    await updateBlockHeightWindowTx.wait();
+
+    transferPrivateTx = await stableTokenContractForAccount.transfer_private_with_creds(
+      recipient,
+      amount,
+      accountRecord,
+      creds,
+      investigatorAddress,
+    );
+    await expect(transferPrivateTx.wait()).rejects.toThrow();
+    transferPrivToPublicTx = await stableTokenContractForAccount.transfer_priv_to_public_creds(
+      recipient,
+      amount,
+      accountRecord,
+      creds,
+      investigatorAddress,
+    );
+    await expect(transferPrivToPublicTx.wait()).rejects.toThrow();
+
+    // bring back the old root
+    updateFreezeListTx = await stableTokenContractForAdmin.update_freeze_list(frozenAccount, true, 1, 1n, root);
+    await updateFreezeListTx.wait();
+    updateBlockHeightWindowTx = await stableTokenContractForAdmin.update_block_height_window(BLOCK_HEIGHT_WINDOW);
+    await updateBlockHeightWindowTx.wait();
+
+    transferPrivateTx = await stableTokenContractForAccount.transfer_private_with_creds(
+      recipient,
+      amount,
+      accountRecord,
+      creds,
+      investigatorAddress,
+    );
+    [complianceRecord, encryptedSenderRecord, encryptedRecipientRecord, encryptedCredRecord] =
+      await transferPrivateTx.wait();
+    creds = await decryptCredentials(encryptedCredRecord, accountPrivKey);
+    expect(creds.owner).toBe(account);
+    expect(creds.freeze_list_root).toBe(root);
+    previousAmount = accountRecord.amount;
+    accountRecord = decryptToken(encryptedSenderRecord, accountPrivKey);
+    recipientRecord = decryptToken(encryptedRecipientRecord, recipientPrivKey);
+    expect(accountRecord.owner).toBe(account);
+    expect(accountRecord.amount).toBe(previousAmount - amount);
+    expect(recipientRecord.owner).toBe(recipient);
+    expect(recipientRecord.amount).toBe(amount);
+
+    decryptedComplianceRecord = decryptComplianceRecord(complianceRecord, investigatorPrivKey);
+    expect(decryptedComplianceRecord.owner).toBe(investigatorAddress);
+    expect(decryptedComplianceRecord.amount).toBe(amount);
+    expect(decryptedComplianceRecord.sender).toBe(account);
+    expect(decryptedComplianceRecord.recipient).toBe(recipient);
+
+    transferPrivToPublicTx = await stableTokenContractForAccount.transfer_priv_to_public_creds(
+      recipient,
+      amount,
+      accountRecord,
+      creds,
+      investigatorAddress,
+    );
+    [complianceRecord, encryptedSenderRecord, encryptedCredRecord] = await transferPrivToPublicTx.wait();
+    creds = await decryptCredentials(encryptedCredRecord, accountPrivKey);
+    expect(creds.owner).toBe(account);
+    expect(creds.freeze_list_root).toBe(root);
+    previousAmount = accountRecord.amount;
+    accountRecord = decryptToken(encryptedSenderRecord, accountPrivKey);
+    expect(accountRecord.owner).toBe(account);
+    expect(accountRecord.amount).toBe(previousAmount - amount);
+
+    decryptedComplianceRecord = decryptComplianceRecord(complianceRecord, investigatorPrivKey);
+    expect(decryptedComplianceRecord.owner).toBe(investigatorAddress);
+    expect(decryptedComplianceRecord.amount).toBe(amount);
+    expect(decryptedComplianceRecord.sender).toBe(account);
+    expect(decryptedComplianceRecord.recipient).toBe(recipient);
+  });
+
+  test(`test old root support`, async () => {
+    const leaves = genLeaves([]);
+    const tree = buildTree(leaves);
+    const senderLeafIndices = getLeafIndices(tree, account);
+    const IncorrectSenderMerkleProof = [
+      getSiblingPath(tree, senderLeafIndices[0], TREE_DEPTH_12),
+      getSiblingPath(tree, senderLeafIndices[1], TREE_DEPTH_12),
+    ];
+    // The transaction failed because the root is mismatch
+    let rejectedTx = await stableTokenContractForAccount.transfer_private(
+      recipient,
+      amount,
+      accountRecord,
+      IncorrectSenderMerkleProof,
+      investigatorAddress,
+    );
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    const updateFreezeListTx = await stableTokenContractForAdmin.update_freeze_list(
+      frozenAccount,
+      false,
+      1,
+      root,
+      1n, // fake root
+    );
+    await updateFreezeListTx.wait();
+
+    const newRoot = await stableTokenContract.freeze_list_root(CURRENT_FREEZE_LIST_ROOT_INDEX);
+    const oldRoot = await stableTokenContract.freeze_list_root(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+    expect(oldRoot).toBe(root);
+    expect(newRoot).toBe(1n);
+
+    // The transaction succeed because the old root is match
+    const tx = await stableTokenContractForAccount.transfer_private(
+      recipient,
+      amount,
+      accountRecord,
+      senderMerkleProof,
+      investigatorAddress,
+    );
+    const [, encryptedAccountRecord] = await tx.wait();
+    accountRecord = decryptToken(encryptedAccountRecord, accountPrivKey);
+
+    const updateBlockHeightWindowTx = await stableTokenContractForAdmin.update_block_height_window(1);
+    await updateBlockHeightWindowTx.wait();
+
+    // The transaction failed because the old root is expired
+    rejectedTx = await stableTokenContractForAccount.transfer_private(
+      recipient,
+      amount,
+      accountRecord,
+      senderMerkleProof,
+      investigatorAddress,
+    );
+    await expect(rejectedTx.wait()).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
The stable token program is a policy that verifies that the sender is not in the freeze list and generates a compliance record for the investigator in all transfers where there is at least one confidential party.

This program doesn't rely on `token_registry` and implements the token functionality independently.
It doesn't rely on an external `merkle_tree` program and implements the merkle_tree functionality itself.
The depth of the Merkle tree is 12.
The recipient for **all** types of transfers can be on the freeze list.
There is a new type of record: `Credentials` record. The record stores the current freeze list root. It allows the owner of the record to provide the record instead of generating a new Merkle proof as long as there are no updates to the Merkle tree.
The user can generate a new `Credentials` record with these functions: `get_credentials`, `transfer_private`, and `transfer_private_to_public`.
After generating this record, the user can use it in the following functions: `transfer_private_with_creds` and `transfer_priv_to_public_creds`.

Main questions:
- How should we name the `Credentials` record?
- Should we allow the generation of a `Credentials` record with a wrong freeze list root? Anyway, they will be invalid when the user tries to use them.
- Should we generate the `Credentials` record also in public transfers?
