### PR TITLE
Reduce get_or_use usage in the programs

### DIFF
--- a/programs/sealance_freezelist_registry.leo
+++ b/programs/sealance_freezelist_registry.leo
@@ -174,7 +174,7 @@ program sealance_freezelist_registry.aleo {
         if (current_root != root) {
             let previous_root: field = freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
             assert_eq(root, previous_root);
-            let window: u32 = block_height_window.get_or_use(BLOCK_HEIGHT_WINDOW_INDEX, 0u32);
+            let window: u32 = block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
             let updated_height: u32 = root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
             assert(updated_height + window > block.height);
         }

--- a/programs/sealed_report_policy.leo
+++ b/programs/sealed_report_policy.leo
@@ -336,7 +336,7 @@ program sealed_report_policy.aleo {
         if (current_root != root) {
             let previous_root: field = freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
             assert_eq(root, previous_root);
-            let window: u32 = block_height_window.get_or_use(BLOCK_HEIGHT_WINDOW_INDEX, 0u32);
+            let window: u32 = block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
             let updated_height: u32 = root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
             assert(updated_height + window > block.height);
         }
@@ -418,7 +418,7 @@ program sealed_report_policy.aleo {
         if (current_root != root) {
             let previous_root: field = freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
             assert_eq(root, previous_root);
-            let window: u32 = block_height_window.get_or_use(BLOCK_HEIGHT_WINDOW_INDEX, 0u32);
+            let window: u32 = block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
             let updated_height: u32 = root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
             assert(updated_height + window > block.height);
         }
@@ -496,7 +496,7 @@ program sealed_report_policy.aleo {
         if (current_root != root) {
             let previous_root: field = freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
             assert_eq(root, previous_root);
-            let window: u32 = block_height_window.get_or_use(BLOCK_HEIGHT_WINDOW_INDEX, 0u32);
+            let window: u32 = block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
             let updated_height: u32 = root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
             assert(updated_height + window > block.height);
         }

--- a/programs/sealed_report_token.leo
+++ b/programs/sealed_report_token.leo
@@ -250,7 +250,7 @@ program sealed_report_token.aleo {
         amount: u128,
         caller: address
     ) {
-        let admin_address: address = roles.get_or_use(ADMIN_INDEX, caller);
+        let admin_address: address = roles.get(ADMIN_INDEX);
         let is_admin: bool = caller == admin_address;
         if(!is_admin) {
             let role: u8 = supply_roles.get(caller);
@@ -299,7 +299,7 @@ program sealed_report_token.aleo {
         amount: u128,
         caller: address,
     ) {
-        let admin_address: address = roles.get_or_use(ADMIN_INDEX, caller);
+        let admin_address: address = roles.get(ADMIN_INDEX);
         let is_admin: bool = caller == admin_address;
         if(!is_admin) {
             let role: u8 = supply_roles.get(caller);
@@ -338,7 +338,7 @@ program sealed_report_token.aleo {
         amount: u128,
         caller: address,
     ) {
-        let admin_address: address = roles.get_or_use(ADMIN_INDEX, caller);
+        let admin_address: address = roles.get(ADMIN_INDEX);
         let is_admin: bool = caller == admin_address;
         if(!is_admin) {
             let role: u8 = supply_roles.get(caller);
@@ -379,7 +379,7 @@ program sealed_report_token.aleo {
         amount: u128,
         caller: address,
     ) {
-        let admin_address: address = roles.get_or_use(ADMIN_INDEX, caller);
+        let admin_address: address = roles.get(ADMIN_INDEX);
         let is_admin: bool = caller == admin_address;
         if(!is_admin) {
             let role: u8 = supply_roles.get(caller);
@@ -577,7 +577,7 @@ program sealed_report_token.aleo {
         if (current_root != root) {
             let previous_root: field = freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
             assert_eq(root, previous_root);
-            let window: u32 = block_height_window.get_or_use(BLOCK_HEIGHT_WINDOW_INDEX, 0u32);
+            let window: u32 = block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
             let updated_height: u32 = root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
             assert(updated_height + window > block.height);
         } 
@@ -638,7 +638,7 @@ program sealed_report_token.aleo {
         if (current_root != root) {
             let previous_root: field = freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
             assert_eq(root, previous_root);
-            let window: u32 = block_height_window.get_or_use(BLOCK_HEIGHT_WINDOW_INDEX, 0u32);
+            let window: u32 = block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
             let updated_height: u32 = root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
             assert(updated_height + window > block.height);
         } 
@@ -699,7 +699,7 @@ program sealed_report_token.aleo {
         if (current_root != root) {
             let previous_root: field = freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
             assert_eq(root, previous_root);
-            let window: u32 = block_height_window.get_or_use(BLOCK_HEIGHT_WINDOW_INDEX, 0u32);
+            let window: u32 = block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
             let updated_height: u32 = root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
             assert(updated_height + window > block.height);
         }
@@ -754,7 +754,7 @@ program sealed_report_token.aleo {
         if (current_root != root) {
             let previous_root: field = freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
             assert_eq(root, previous_root);
-            let window: u32 = block_height_window.get_or_use(BLOCK_HEIGHT_WINDOW_INDEX, 0u32);
+            let window: u32 = block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
             let updated_height: u32 = root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
             assert(updated_height + window > block.height);
         }    


### PR DESCRIPTION
Use get instead of get_or_use for block_height_window mapping (we initialized this mapping, so it has to be non-empty).
Use the get function in the minting and burning functions, so it will not be possible to mint or burn before we set an admin.