### PR TITLE
Fix the Merkle tree program vulnerability for second preimage attacks

### DIFF
--- a/lib/MerkleTree.ts
+++ b/lib/MerkleTree.ts
@@ -6,12 +6,12 @@ import { ZERO_ADDRESS, MAX_TREE_SIZE } from "./Constants";
  * Hashes two elements using Poseidon4 hash function
  * @throws {Error} If inputs are empty or invalid
  */
-function hashTwoElements(el1: string, el2: string): Field {
+function hashTwoElements(prefix: string, el1: string, el2: string): Field {
   if (!el1 || !el2) {
     throw new Error("Invalid inputs: elements cannot be empty");
   }
   const hasher = new Poseidon4();
-  const fields = [Field.fromString(el1), Field.fromString(el2)];
+  const fields = [Field.fromString(prefix), Field.fromString(el1), Field.fromString(el2)];
   const arrayPlaintext = Plaintext.fromString(`[${fields.map(f => f.toString()).join(",")}]`);
 
   return hasher.hash(arrayPlaintext.toFields());
@@ -38,7 +38,8 @@ export function buildTree(leaves: string[]): bigint[] {
     for (let i = 0; i < levelSize; i += 2) {
       const left = currentLevel[i];
       const right = currentLevel[i + 1];
-      const hash = hashTwoElements(left, right);
+      const prefix = leaves.length === levelSize ? "1field" : "0field";
+      const hash = hashTwoElements(prefix, left, right);
       nextLevel.push(hash.toString());
     }
     tree = [...tree, ...nextLevel];

--- a/programs/merkle_tree.leo
+++ b/programs/merkle_tree.leo
@@ -15,8 +15,13 @@ program merkle_tree.aleo {
     // Calculates the hash of two sibling nodes in a Merkle tree.
     // The order of the siblings depends on the index bit (0 = left, 1 = right).
     // Uses Poseidon hash to compute the result.
-    inline calculate_hash_for_neighbor(sibling1: field, sibling2: field, indexbit: u32) -> field {
-        let poseidon_params: [field; 2] = indexbit == 0u32 ? [sibling1, sibling2] : [sibling2, sibling1];
+    inline calculate_hash_for_nodes(sibling1: field, sibling2: field, indexbit: u32) -> field {
+        let poseidon_params: [field; 3] = indexbit == 0u32 ? [0field, sibling1, sibling2] : [0field, sibling2, sibling1];
+        return Poseidon4::hash_to_field(poseidon_params);
+    }
+
+    inline calculate_hash_for_leaves(sibling1: field, sibling2: field, indexbit: u32) -> field {
+        let poseidon_params: [field; 3] = indexbit == 0u32 ? [1field, sibling1, sibling2] : [1field, sibling2, sibling1];
         return Poseidon4::hash_to_field(poseidon_params);
     }
 
@@ -25,12 +30,12 @@ program merkle_tree.aleo {
     // Stops when a zero field is encountered in the siblings array, indicating the end of the valid path.
     // Returns the calculated root and the actual depth reached.
     inline calculate_root_depth_siblings(merkle_proof: MerkleProof) -> (public field, public u32) {
-        let root: field = calculate_hash_for_neighbor(merkle_proof.siblings[0u8], merkle_proof.siblings[1u8],  merkle_proof.leaf_index % 2u32);
+        let root: field = calculate_hash_for_leaves(merkle_proof.siblings[0u8], merkle_proof.siblings[1u8],  merkle_proof.leaf_index % 2u32);
         for i: u32 in 2u32..MAX_TREE_DEPTH + 1u32 {
             if (merkle_proof.siblings[i] == 0field) {
                 return (root, i);
             }
-            root = calculate_hash_for_neighbor(root, merkle_proof.siblings[i], (merkle_proof.leaf_index / (2u32**(i-1u32))) % 2u32);
+            root = calculate_hash_for_nodes(root, merkle_proof.siblings[i], (merkle_proof.leaf_index / (2u32**(i-1u32))) % 2u32);
         }
         return (root, MAX_TREE_DEPTH);
     }


### PR DESCRIPTION
We fixed it by adding hashing the leaves with `1field` and hashing the intermediate nodes with `0field`.
We added a test that tries to do a second preimage attack.
This test is failing with the old Merkle tree program and off-chain hashing functions.