### PR TITLE
ci: upgrade GitHub Actions and harden workflow shell configuration 

### DIFF
--- a/.github/workflows/leo-cache-warmup.yml
+++ b/.github/workflows/leo-cache-warmup.yml
@@ -25,6 +25,9 @@ jobs:
       contents: read
       actions: write # Required for cache operations
     timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash -eo pipefail {0}
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -44,20 +47,22 @@ jobs:
 
       - name: Report cache status
         run: |
-          echo "## Leo CLI Cache Warmup Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Metric | Value |" >> $GITHUB_STEP_SUMMARY
-          echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Leo Version | 3.4.0 |" >> $GITHUB_STEP_SUMMARY
-          echo "| Rust Version | 1.90.0 |" >> $GITHUB_STEP_SUMMARY
-          echo "| Cache Hit (Binary) | $CACHE_HIT_BINARY |" >> $GITHUB_STEP_SUMMARY
-          echo "| Build Time | ${BUILD_TIME_SECONDS}s |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          if [ "$CACHE_HIT_BINARY" = "true" ]; then
-            echo "Cache was already warm - refreshed for another 7 days" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "Cache miss - Leo was compiled from source and cached" >> $GITHUB_STEP_SUMMARY
-          fi
+          {
+            echo "## Leo CLI Cache Warmup Summary"
+            echo ""
+            echo "| Metric | Value |"
+            echo "|--------|-------|"
+            echo "| Leo Version | 3.4.0 |"
+            echo "| Rust Version | 1.90.0 |"
+            echo "| Cache Hit (Binary) | $CACHE_HIT_BINARY |"
+            echo "| Build Time | ${BUILD_TIME_SECONDS}s |"
+            echo ""
+            if [ "$CACHE_HIT_BINARY" = "true" ]; then
+              echo "Cache was already warm - refreshed for another 7 days"
+            else
+              echo "Cache miss - Leo was compiled from source and cached"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
         env:
           CACHE_HIT_BINARY: ${{ steps.setup-leo.outputs.cache-hit-binary }}
           BUILD_TIME_SECONDS: ${{ steps.setup-leo.outputs.build-time-seconds }}

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -21,6 +21,9 @@ jobs:
       contents: read
     outputs:
       has_commits: ${{ steps.check.outputs.has_commits }}
+    defaults:
+      run:
+        shell: bash -eo pipefail {0}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
@@ -31,10 +34,10 @@ jobs:
         run: |
           COMMITS=$(git log --oneline --since="24 hours ago" origin/main | wc -l)
           if [ "$COMMITS" -gt 0 ]; then
-            echo "has_commits=true" >> $GITHUB_OUTPUT
+            echo "has_commits=true" >> "$GITHUB_OUTPUT"
             echo "Found $COMMITS commit(s) in last 24 hours"
           else
-            echo "has_commits=false" >> $GITHUB_OUTPUT
+            echo "has_commits=false" >> "$GITHUB_OUTPUT"
             echo "No commits in last 24 hours, skipping tests"
           fi
 
@@ -47,6 +50,9 @@ jobs:
       contents: read
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+    defaults:
+      run:
+        shell: bash -eo pipefail {0}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
@@ -57,7 +63,7 @@ jobs:
           # Find all test files and create JSON array
           # Uses -exec instead of xargs to safely handle special characters in filenames
           files=$(find test -name "*.test.ts" -type f -exec basename {} \; | jq -R -s -c 'split("\n") | map(select(. != ""))')
-          echo "matrix={\"test-file\":$files}" >> $GITHUB_OUTPUT
+          echo "matrix={\"test-file\":$files}" >> "$GITHUB_OUTPUT"
           echo "Discovered test files: $files"
 
   test-devnet:
@@ -86,6 +92,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {} # No permissions needed - just checks job results
+    defaults:
+      run:
+        shell: bash -eo pipefail {0}
     steps:
       - name: Check results
         run: |

--- a/.github/workflows/on-pull-request-main-sdk.yml
+++ b/.github/workflows/on-pull-request-main-sdk.yml
@@ -45,6 +45,9 @@ jobs:
       contents: read
     outputs:
       sdk: ${{ steps.filter.outputs.sdk }}
+    defaults:
+      run:
+        shell: bash -eo pipefail {0}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
@@ -60,11 +63,11 @@ jobs:
           SDK_CHANGES=$(echo "$CHANGED" | grep '^packages/policy-engine-sdk/' | grep -vE '\.md$' | grep -v '^packages/policy-engine-sdk/examples/' || echo "")
 
           if [[ -n "$SDK_CHANGES" ]]; then
-            echo "sdk=true" >> $GITHUB_OUTPUT
+            echo "sdk=true" >> "$GITHUB_OUTPUT"
             echo "SDK code changes detected:"
             echo "$SDK_CHANGES"
           else
-            echo "sdk=false" >> $GITHUB_OUTPUT
+            echo "sdk=false" >> "$GITHUB_OUTPUT"
             echo "No SDK code changes"
           fi
         env:
@@ -77,6 +80,9 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+    defaults:
+      run:
+        shell: bash -eo pipefail {0}
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -109,6 +115,9 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+    defaults:
+      run:
+        shell: bash -eo pipefail {0}
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -148,6 +157,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {} # No permissions needed - just checks job results
+    defaults:
+      run:
+        shell: bash -eo pipefail {0}
     steps:
       - name: Check results
         run: |

--- a/.github/workflows/on-pull-request-main.yml
+++ b/.github/workflows/on-pull-request-main.yml
@@ -51,6 +51,9 @@ jobs:
       contents: read
     outputs:
       code: ${{ steps.filter.outputs.code }}
+    defaults:
+      run:
+        shell: bash -eo pipefail {0}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6.0.1
         with:
@@ -64,10 +67,10 @@ jobs:
 
           # Check if any non-markdown files changed
           if echo "$CHANGED" | grep -qvE '\.md$'; then
-            echo "code=true" >> $GITHUB_OUTPUT
+            echo "code=true" >> "$GITHUB_OUTPUT"
             echo "Code changes detected"
           else
-            echo "code=false" >> $GITHUB_OUTPUT
+            echo "code=false" >> "$GITHUB_OUTPUT"
             echo "No code changes (docs only)"
           fi
         env:
@@ -80,6 +83,9 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+    defaults:
+      run:
+        shell: bash -eo pipefail {0}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6.0.1
         with:
@@ -104,8 +110,14 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+    defaults:
+      run:
+        shell: bash -eo pipefail {0}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6.0.1
         with:
@@ -116,7 +128,7 @@ jobs:
           # Find all test files and create JSON array
           # Uses -exec instead of xargs to safely handle special characters in filenames
           files=$(find test -name "*.test.ts" -type f -exec basename {} \; | jq -R -s -c 'split("\n") | map(select(. != ""))')
-          echo "matrix={\"test-file\":$files}" >> $GITHUB_OUTPUT
+          echo "matrix={\"test-file\":$files}" >> "$GITHUB_OUTPUT"
           echo "Discovered test files: $files"
 
   # Devnet mode: Matrix of jobs for ALL tests (default)
@@ -162,6 +174,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {} # No permissions needed - just checks job results
+    defaults:
+      run:
+        shell: bash -eo pipefail {0}
     steps:
       - name: Check results
         run: |

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -36,6 +36,9 @@ jobs:
       contents: read
     outputs:
       workflows: ${{ steps.filter.outputs.workflows }}
+    defaults:
+      run:
+        shell: bash -eo pipefail {0}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
@@ -53,7 +56,7 @@ jobs:
             CHANGED=$(git diff --name-only "origin/$BASE_REF...HEAD" 2>/dev/null || echo "")
           # For scheduled/manual runs, always run
           else
-            echo "workflows=true" >> $GITHUB_OUTPUT
+            echo "workflows=true" >> "$GITHUB_OUTPUT"
             echo "Scheduled/manual run - always audit"
             exit 0
           fi
@@ -62,11 +65,11 @@ jobs:
           WORKFLOW_CHANGES=$(echo "$CHANGED" | grep -E '^\.github/(workflows/|zizmor\.yml|dependabot\.yml)' || echo "")
 
           if [[ -n "$WORKFLOW_CHANGES" ]]; then
-            echo "workflows=true" >> $GITHUB_OUTPUT
+            echo "workflows=true" >> "$GITHUB_OUTPUT"
             echo "Workflow changes detected:"
             echo "$WORKFLOW_CHANGES"
           else
-            echo "workflows=false" >> $GITHUB_OUTPUT
+            echo "workflows=false" >> "$GITHUB_OUTPUT"
             echo "No workflow changes"
           fi
         env:
@@ -115,6 +118,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {} # No permissions needed - just checks job results
+    defaults:
+      run:
+        shell: bash -eo pipefail {0}
     steps:
       - name: Check results
         run: |

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 240 # 4 hours for devnet based tests
     defaults:
       run:
-        shell: bash
+        shell: bash -eo pipefail {0}
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                               
  - Upgraded GitHub Actions to latest SHA-pinned versions                                                                                                                                                                                                                      
    - actions/checkout v4.3.0 → v6.0.1                                                                                                                                                                                                                                         
    - actions/setup-node v4.4.0 → v6.2.0                                                                                                                                                                                                                                       
    - zizmorcore/zizmor-action v0.2.0 → v0.3.0                                                                                                                                                                                                                                 
  - Added strict bash shell mode across all workflows                                                                                                                                                                                                                          
    - Configured shell: bash -eo pipefail {0} for fail-fast behavior on errors and broken pipes                                                                                                                                                                                
  - Hardened shell scripting practices                                                                                                                                                                                                                                         
    - Quoted $GITHUB_OUTPUT and $GITHUB_STEP_SUMMARY variable references                                                                                                                                                                                                       
    - Refactored multi-line echo blocks to use compound redirects                                                                                                                                                                                                              
  - Additional job hardening                                                                                                                                                                                                                                                   
    - Added missing timeout-minutes and permissions to discover-tests job 