### PR TITLE
Align the SDK and TypeScript MAX_TREE_DEPTH constant with Leo's

### DIFF
--- a/.changeset/align-freezelist-tree-depth.md
+++ b/.changeset/align-freezelist-tree-depth.md
@@ -1,0 +1,5 @@
+---
+"@sealance-io/policy-engine-aleo": minor
+---
+
+**Breaking:** `getSiblingPath` third parameter renamed from `depth` (path length) to `maxTreeDepth` (tree depth, default: 15). Callers passing `16` should now pass `15` or omit the argument. The function internally pads to `maxTreeDepth + 1` elements.

--- a/lib/Constants.ts
+++ b/lib/Constants.ts
@@ -88,8 +88,9 @@ export const MULTISIG_OP_BURN_PRIVATE = 7;
 export const MULTISIG_OP_UPDATE_BLOCK_WINDOW = 3;
 export const MULTISIG_OP_UPDATE_FREEZE_LIST = 4;
 
-// merkle tree
-export const MAX_TREE_DEPTH = 16;
+// Maximum depth of the Merkle tree used in freeze list proofs (matches Leo MAX_TREE_DEPTH).
+// The MerkleProof siblings array has MAX_TREE_DEPTH + 1 elements: [leaf, sibling_1, ..., sibling_depth].
+export const MAX_TREE_DEPTH = 15;
 
 // testing constant
 export const defaultAuthorizedUntil = 4294967295;

--- a/packages/policy-engine-sdk/API.md
+++ b/packages/policy-engine-sdk/API.md
@@ -142,7 +142,7 @@ const tree = buildTree(leaves);
 const [leftIdx, rightIdx] = getLeafIndices(tree, "aleo1...");
 
 // Get sibling path (Merkle proof)
-const proof = getSiblingPath(tree, leftIdx, 16);
+const proof = getSiblingPath(tree, leftIdx, 15);
 ```
 
 ### Transaction Tracking

--- a/packages/policy-engine-sdk/src/merkle-tree.ts
+++ b/packages/policy-engine-sdk/src/merkle-tree.ts
@@ -157,20 +157,21 @@ export function getLeafIndices(merkleTree: bigint[], address: string): [number, 
  *
  * @param tree - The complete Merkle tree
  * @param leafIndex - Index of the leaf to generate proof for
- * @param depth - Maximum depth of the tree
+ * @param maxTreeDepth - Maximum depth of the tree (default: 15, matching Leo's MAX_TREE_DEPTH).
+ *   The returned siblings array will have maxTreeDepth + 1 elements.
  * @returns Object containing siblings array and leaf_index
  *
  * @example
  * ```typescript
  * const tree = buildTree(leaves);
- * const proof = getSiblingPath(tree, 0, 15);
- * // proof = { siblings: [0n, 1n, ...], leaf_index: 0 }
+ * const proof = getSiblingPath(tree, 0);
+ * // proof.siblings has 16 elements: [leaf, sibling_1, ..., sibling_15]
  * ```
  */
 export function getSiblingPath(
   tree: bigint[],
   leafIndex: number,
-  depth: number,
+  maxTreeDepth: number = 15,
 ): { siblings: bigint[]; leaf_index: number } {
   let num_leaves = Math.floor((tree.length + 1) / 2);
   const siblingPath: bigint[] = [];
@@ -188,7 +189,8 @@ export function getSiblingPath(
     level++;
   }
 
-  while (level < depth) {
+  // Pad to maxTreeDepth + 1 elements (leaf + depth siblings)
+  while (level < maxTreeDepth + 1) {
     siblingPath.push(0n);
     level++;
   }

--- a/packages/policy-engine-sdk/src/policy-engine.ts
+++ b/packages/policy-engine-sdk/src/policy-engine.ts
@@ -255,8 +255,8 @@ export class PolicyEngine {
     const [leftLeafIndex, rightLeafIndex] = getLeafIndices(tree, address);
 
     // Generate sibling paths
-    const leftProof = getSiblingPath(tree, leftLeafIndex, this.config.maxTreeDepth + 1);
-    const rightProof = getSiblingPath(tree, rightLeafIndex, this.config.maxTreeDepth + 1);
+    const leftProof = getSiblingPath(tree, leftLeafIndex, this.config.maxTreeDepth);
+    const rightProof = getSiblingPath(tree, rightLeafIndex, this.config.maxTreeDepth);
 
     const proofs: [MerkleProof, MerkleProof] = [
       {

--- a/packages/policy-engine-sdk/test/merkle-tree.test.ts
+++ b/packages/policy-engine-sdk/test/merkle-tree.test.ts
@@ -144,7 +144,7 @@ describe("merkle_tree lib, getSiblingPath", () => {
     expect(proof).toBeDefined();
     expect(proof.leaf_index).toBe(1);
     expect(proof.siblings).toBeDefined();
-    expect(proof.siblings.length).toBe(15); // Depth 15
+    expect(proof.siblings.length).toBe(16); // maxTreeDepth + 1
     expect(proof.siblings[0]).toBe(2n); // The leaf itself (index 1 = "2field")
     expect(proof.siblings[1]).toBe(1n); // Its sibling (index 0 = "1field")
   });

--- a/programs/core/merkle_tree.leo
+++ b/programs/core/merkle_tree.leo
@@ -2,8 +2,8 @@ program merkle_tree.aleo {
     @noupgrade
     async constructor() {}
 
-    // Defines the maximum depth of the Merkle tree used in freeze list proofs.
-    // Trees deeper than this value are not supported.
+    // Maximum depth of the Merkle tree used in freeze list proofs.
+    // The siblings array has MAX_TREE_DEPTH + 1 elements because siblings[0] holds the leaf itself.
     const MAX_TREE_DEPTH: u32 = 15u32;
     
     struct MerkleProof {

--- a/programs/token/compliant_token_template.leo
+++ b/programs/token/compliant_token_template.leo
@@ -85,8 +85,8 @@ program compliant_token_template.aleo {
     const PREVIOUS_FREEZE_LIST_ROOT_INDEX: u8 = 2u8;
     const BLOCK_HEIGHT_WINDOW_INDEX: bool = true;
     const ROOT_UPDATED_HEIGHT_INDEX: bool = true;
-    // Defines the maximum depth of the Merkle tree used in freeze list proofs.
-    // Trees deeper than this value are not supported.
+    // Maximum depth of the Merkle tree used in freeze list proofs.
+    // The siblings array has MAX_TREE_DEPTH + 1 elements because siblings[0] holds the leaf itself.
     const MAX_TREE_DEPTH: u32 = 15u32;
 
     // -------------------------

--- a/programs/token/multisig_compliant_token.leo
+++ b/programs/token/multisig_compliant_token.leo
@@ -82,8 +82,8 @@ program multisig_compliant_token.aleo {
     const PREVIOUS_FREEZE_LIST_ROOT_INDEX: u8 = 2u8;
     const BLOCK_HEIGHT_WINDOW_INDEX: bool = true;
     const ROOT_UPDATED_HEIGHT_INDEX: bool = true;
-    // Defines the maximum depth of the Merkle tree used in freeze list proofs.
-    // Trees deeper than this value are not supported.
+    // Maximum depth of the Merkle tree used in freeze list proofs.
+    // The siblings array has MAX_TREE_DEPTH + 1 elements because siblings[0] holds the leaf itself.
     const MAX_TREE_DEPTH: u32 = 15u32;
 
     const MULTISIG_OP_UPDATE_WALLET_ROLE: u8 = 1u8;


### PR DESCRIPTION
## Summay ##
- Align the SDK and TypeScript MAX_TREE_DEPTH constant with Leo's MAX_TREE_DEPTH = 15 (was 16 in lib/Constants.ts)                                                                                                 
- Rename getSiblingPath third parameter from depth (path length) to maxTreeDepth (tree depth, default 15); the function now internally pads to maxTreeDepth + 1 elements
- Fix PolicyEngine.getSiblingPath call to pass this.config.maxTreeDepth directly (no + 1)                                                                                                                          
- Update Leo program comments, SDK docs, and tests to reflect the aligned semantics

## Notes ##

No behavioral change. getSiblingPath(tree, idx, 15) with the new +1 padding produces the same 16-element array that getSiblingPath(tree, idx, 16) produced before. On-chain programs are unchanged.

## Test plan ##

- SDK unit tests pass (npm run test --workspace=@sealance-io/policy-engine-aleo)
- Integration tests pass against devnet