### PR TITLE
fix: publish sdk releases from main

### DIFF
--- a/.github/workflows/sdk-release-publish.yml
+++ b/.github/workflows/sdk-release-publish.yml
@@ -1,10 +1,13 @@
 name: SDK Release - Publish
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches:
       - main
+    paths:
+      - "packages/policy-engine-sdk/package.json"
+      - "packages/policy-engine-sdk/CHANGELOG.md"
+  workflow_dispatch:
 
 # No default permissions - jobs must explicitly request what they need
 permissions: {}
@@ -14,12 +17,13 @@ concurrency:
   cancel-in-progress: false # Never cancel publishing
 
 jobs:
-  # Gate: Only proceed if this is a merged release PR
+  # Gate: Only proceed if this push came from a merged release PR
   check-release:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       should_publish: ${{ steps.check.outputs.should_publish }}
       version: ${{ steps.version.outputs.version }}
@@ -27,21 +31,45 @@ jobs:
       run:
         shell: bash -eo pipefail {0}
     steps:
-      - name: Check if release PR
+      - name: Check if push came from release PR
         id: check
-        run: |
-          # Primary check: source branch is changeset-release/main (canonical changesets pattern)
-          # This is more robust than title matching since the branch name is deterministic
-          if [[ "$PR_MERGED" == "true" && "$HEAD_REF" == "changeset-release/main" ]]; then
-            echo "should_publish=true" >> "$GITHUB_OUTPUT"
-            echo "Release PR detected (branch: $HEAD_REF) - proceeding to publish"
-          else
-            echo "should_publish=false" >> "$GITHUB_OUTPUT"
-            echo "Not a release PR (merged=$PR_MERGED, branch=$HEAD_REF) - skipping"
-          fi
-        env:
-          PR_MERGED: ${{ github.event.pull_request.merged }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            if (context.eventName === 'workflow_dispatch') {
+              if (context.ref !== 'refs/heads/main') {
+                core.setOutput('should_publish', 'false');
+                console.log(`Manual publish requested from ${context.ref} - only main is allowed`);
+                return;
+              }
+
+              core.setOutput('should_publish', 'true');
+              console.log(`Manual publish requested from ${context.ref} - proceeding to publish`);
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            const commitSha = context.sha;
+
+            const { data: pullRequests } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner,
+              repo,
+              commit_sha: commitSha
+            });
+
+            const releasePr = pullRequests.find((pr) =>
+              pr.merged_at &&
+              pr.base.ref === 'main' &&
+              pr.head.ref === 'changeset-release/main'
+            );
+
+            if (releasePr) {
+              core.setOutput('should_publish', 'true');
+              console.log(`Release PR #${releasePr.number} detected for ${commitSha} - proceeding to publish`);
+            } else {
+              core.setOutput('should_publish', 'false');
+              console.log(`No merged release PR associated with ${commitSha} - skipping publish`);
+            }
 
       - name: Checkout
         if: steps.check.outputs.should_publish == 'true'
@@ -173,11 +201,7 @@ jobs:
           script: |
             const version = process.env.PACKAGE_VERSION;
             const tag = `@sealance-io/policy-engine-aleo@${version}`;
-            const releaseSha = context.payload.pull_request?.merge_commit_sha;
-
-            if (!releaseSha) {
-              throw new Error('Missing pull_request.merge_commit_sha for merged PR release tagging');
-            }
+            const releaseSha = context.sha;
 
             // Create tag (idempotent - handle re-runs gracefully)
             try {

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -236,11 +236,13 @@ When reviewing PRs that modify the SDK:
 
 2. **Review & Merge**: Maintainer reviews the version bumps and CHANGELOG updates, then merges
 
-3. **Approval Required**: When the release PR is merged, the `sdk-release-publish.yml` workflow runs but pauses for admin approval (GitHub environment protection)
+3. **Approval Required**: When the release PR is merged, the resulting `push` to `main` triggers `sdk-release-publish.yml`, which then pauses for admin approval (GitHub environment protection)
 
 4. **Publish**: After approval:
    - Package is published to npm via OIDC (with provenance and retry logic)
    - GitHub Release is created with tag (idempotent - safe to re-run)
+
+If the publish workflow itself was broken at merge time, maintainers can run `sdk-release-publish.yml` manually from `main` after the workflow fix lands. The same `npm-publish` environment approval still applies.
 
 ### Pre-release Versions (Alpha/Beta/RC)
 
@@ -533,6 +535,7 @@ After release, verify:
 
 - Verify `npm-publish` environment exists with required reviewers
 - Check the workflow uses `environment: npm-publish`
+- Verify the publish workflow is triggered by `push` to `main` rather than a `pull_request` ref such as `refs/pull/<n>/merge`
 
 ### Provenance Not Generated
 
@@ -546,6 +549,7 @@ The workflow is fully idempotent. If a re-run is needed (e.g., npm published but
 - npm publish checks if the version already exists via `npm view` and skips publishing if so
 - GitHub tag/release creation skips if already exists
 - Check the `Release Status` job for the actual outcome
+- If the original run failed before reaching approval because the workflow itself was misconfigured, use `workflow_dispatch` to run `sdk-release-publish.yml` from `main` after merging the fix
 
 ---
 
@@ -595,7 +599,7 @@ This allows safe workflow re-runs after partial failures (e.g., npm published bu
 
 ### Release Detection
 
-The publish workflow detects release PRs by checking the source branch name (`changeset-release/main`), which is more robust than PR title matching since the branch name is deterministic and set by changesets.
+The publish workflow normally runs on `push` to `main` so it satisfies the environment's `main`-only deployment rule. It then checks which PR is associated with the pushed commit and only publishes if that merged PR came from the `changeset-release/main` branch. For recovery, maintainers can also trigger the workflow manually on `main`; that path still requires the protected environment approval before publishing.
 
 ---
 
@@ -607,8 +611,8 @@ The publish workflow detects release PRs by checking the source branch name (`ch
 4. **Environment protection**: Publishing requires reviewer approval via GitHub environments
 5. **Cache disabled**: Release workflows disable npm caching to prevent cache poisoning attacks
 6. **Fresh downloads**: Dependencies are downloaded fresh from npm registry during releases
-7. **Branch restrictions**: Only workflows on `main` can trigger publishing
+7. **Branch restrictions**: Only workflows running on `main` can trigger publishing or request the protected environment
 
 ---
 
-**Last Updated**: 2026-02-10
+**Last Updated**: 2026-03-17


### PR DESCRIPTION
## Summary

  Fix the SDK release publish workflow so protected npm deployment approval works after merging the Changesets release PR.

  ## Root Cause

  sdk-release-publish.yml was triggered by pull_request.closed, so the publish job ran on a ref like refs/pull/212/merge instead of refs/heads/main.

  Because the npm-publish environment only allows deployments from main, GitHub rejected the job before reviewers could approve it.

  ## Changes

  - Switch sdk-release-publish.yml to trigger on push to main
  - Keep release gating by checking that the pushed commit is associated with a merged changeset-release/main PR
  - Add workflow_dispatch support for manual recovery if a release was missed due to the old workflow
  - Update docs/RELEASING.md to document the corrected flow and recovery path

  ## Result

  - Release publishes now request the protected npm-publish environment from main
  - Reviewers can approve deployments as intended
  - Missed releases can be recovered by manually running the publish workflow from main