### PR TITLE
Initial stable swap

### DIFF
--- a/packages/policy-engine-sdk/src/amm-pool.ts
+++ b/packages/policy-engine-sdk/src/amm-pool.ts
@@ -1,0 +1,360 @@
+const DEFAULT_MAX_ITERATIONS = 12;
+const DEFAULT_AMPLIFICATION = 85n;
+const MAX_U128 = (1n << 128n) - 1n;
+
+const DEFAULT_FEE = 6_000_000n;
+const DEFAULT_ADMIN_FEE = 0n;
+const DEFAULT_FEE_DENOMINATOR = 10_000_000_000n;
+
+type PoolBalances = readonly [bigint, bigint];
+
+export interface AmmFeesConfig {
+  fee?: bigint;
+  adminFee?: bigint;
+  feeDenominator?: bigint;
+}
+
+export interface AmmMathConfig {
+  maxIterations?: number;
+  amplification?: bigint;
+  fees?: AmmFeesConfig;
+}
+
+export interface ResolvedAmmMathConfig {
+  maxIterations: number;
+  amplification: bigint;
+  ann: bigint;
+  fee: bigint;
+  adminFee: bigint;
+  feeDenominator: bigint;
+}
+
+export interface ExchangeQuoteInput {
+  inputAmount: bigint;
+  inputTokenBalance: bigint;
+  outputTokenBalance: bigint;
+}
+
+export interface ExchangeQuote {
+  newInputStableTokenBalance: bigint;
+  newOutputStableTokenBalance: bigint;
+  grossOutputAmount: bigint;
+  feeAmount: bigint;
+  adminFeeAmount: bigint;
+  netOutputAmount: bigint;
+}
+
+export interface AddLiquidityQuoteInput {
+  stableToken1Amount: bigint;
+  stableToken2Amount: bigint;
+  stableToken1Balance: bigint;
+  stableToken2Balance: bigint;
+  lpTokenSupply: bigint;
+}
+
+export interface AddLiquidityQuote {
+  invariantBefore: bigint;
+  invariantAfterDeposit: bigint;
+  invariantAfterFee: bigint;
+  balancesAfterDeposit: [bigint, bigint];
+  balancesAfterFee: [bigint, bigint];
+  stableToken1Fee: bigint;
+  stableToken2Fee: bigint;
+  newStableToken1Balance: bigint;
+  newStableToken2Balance: bigint;
+  mintAmount: bigint;
+}
+
+export interface RemoveLiquidityQuoteInput {
+  lpTokenAmount: bigint;
+  stableToken1Balance: bigint;
+  stableToken2Balance: bigint;
+  lpTokenSupply: bigint;
+}
+
+export interface RemoveLiquidityQuote {
+  stableToken1Amount: bigint;
+  stableToken2Amount: bigint;
+  newStableToken1Balance: bigint;
+  newStableToken2Balance: bigint;
+}
+
+export const DEFAULT_AMM_MATH_CONFIG: Readonly<ResolvedAmmMathConfig> = {
+  maxIterations: DEFAULT_MAX_ITERATIONS,
+  amplification: DEFAULT_AMPLIFICATION,
+  ann: DEFAULT_AMPLIFICATION * 2n,
+  fee: DEFAULT_FEE,
+  adminFee: DEFAULT_ADMIN_FEE,
+  feeDenominator: DEFAULT_FEE_DENOMINATOR,
+};
+
+function assertU128(name: string, value: bigint) {
+  if (value < 0n) {
+    throw new Error(`${name} must be a non-negative bigint`);
+  }
+
+  if (value > MAX_U128) {
+    throw new Error(`${name} must fit within u128`);
+  }
+}
+
+function assertPositive(name: string, value: bigint) {
+  if (value <= 0n) {
+    throw new Error(`${name} must be greater than zero`);
+  }
+}
+
+function absoluteDifference(a: bigint, b: bigint): bigint {
+  return a > b ? a - b : b - a;
+}
+
+function assertValidMaxIterations(value: number) {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error("maxIterations must be a non-negative integer");
+  }
+}
+
+function resolveAmmMathConfig(config: AmmMathConfig = {}): ResolvedAmmMathConfig {
+  const maxIterations = config.maxIterations ?? DEFAULT_MAX_ITERATIONS;
+  const amplification = config.amplification ?? DEFAULT_AMPLIFICATION;
+  const fee = config.fees?.fee ?? DEFAULT_FEE;
+  const adminFee = config.fees?.adminFee ?? DEFAULT_ADMIN_FEE;
+  const feeDenominator = config.fees?.feeDenominator ?? DEFAULT_FEE_DENOMINATOR;
+
+  assertValidMaxIterations(maxIterations);
+  assertU128("amplification", amplification);
+  assertU128("fee", fee);
+  assertU128("adminFee", adminFee);
+  assertU128("feeDenominator", feeDenominator);
+  assertPositive("feeDenominator", feeDenominator);
+
+  return {
+    maxIterations,
+    amplification,
+    ann: amplification * 2n,
+    fee,
+    adminFee,
+    feeDenominator,
+  };
+}
+
+export function computeInvariant(tokenBalances: PoolBalances, config?: AmmMathConfig): bigint {
+  const [stableToken1Balance, stableToken2Balance] = tokenBalances;
+  const ammConfig = resolveAmmMathConfig(config);
+
+  assertU128("tokenBalances[0]", stableToken1Balance);
+  assertU128("tokenBalances[1]", stableToken2Balance);
+
+  const totalBalance = stableToken1Balance + stableToken2Balance;
+  if (totalBalance === 0n) {
+    return 0n;
+  }
+
+  let invariant = totalBalance;
+
+  for (let i = 0; i < ammConfig.maxIterations; i++) {
+    let productTerm = (invariant * invariant) / (stableToken1Balance * 2n + 1n);
+    productTerm = (productTerm * invariant) / (stableToken2Balance * 2n + 1n);
+
+    const previousInvariant = invariant;
+    invariant =
+      ((ammConfig.ann * totalBalance + productTerm * 2n) * invariant) /
+      ((ammConfig.ann - 1n) * invariant + 3n * productTerm);
+
+    if (absoluteDifference(invariant, previousInvariant) <= 1n) {
+      return invariant;
+    }
+  }
+
+  return invariant;
+}
+
+export function computeOutputTokenBalance(
+  newInputTokenBalance: bigint,
+  inputTokenBalance: bigint,
+  outputTokenBalance: bigint,
+  config?: AmmMathConfig,
+): bigint {
+  const ammConfig = resolveAmmMathConfig(config);
+
+  assertU128("newInputTokenBalance", newInputTokenBalance);
+  assertU128("inputTokenBalance", inputTokenBalance);
+  assertU128("outputTokenBalance", outputTokenBalance);
+  assertPositive("newInputTokenBalance", newInputTokenBalance);
+
+  const invariant = computeInvariant([inputTokenBalance, outputTokenBalance], ammConfig);
+
+  let productTerm = invariant;
+  productTerm = (productTerm * invariant) / (newInputTokenBalance * 2n);
+  productTerm = (productTerm * invariant) / (ammConfig.ann * 2n);
+
+  const sumTerm = newInputTokenBalance + invariant / ammConfig.ann;
+
+  let newOutputTokenBalance = invariant;
+  for (let i = 0; i < ammConfig.maxIterations; i++) {
+    const previousEstimate = newOutputTokenBalance;
+    newOutputTokenBalance =
+      (newOutputTokenBalance * newOutputTokenBalance + productTerm) /
+      (2n * newOutputTokenBalance + sumTerm - invariant);
+
+    if (absoluteDifference(newOutputTokenBalance, previousEstimate) <= 1n) {
+      return newOutputTokenBalance;
+    }
+  }
+
+  return newOutputTokenBalance;
+}
+
+export function calculateExchangeQuote(
+  { inputAmount, inputTokenBalance, outputTokenBalance }: ExchangeQuoteInput,
+  config?: AmmMathConfig,
+): ExchangeQuote {
+  const ammConfig = resolveAmmMathConfig(config);
+
+  assertU128("inputAmount", inputAmount);
+  assertU128("inputTokenBalance", inputTokenBalance);
+  assertU128("outputTokenBalance", outputTokenBalance);
+
+  const newInputTokenBalance = inputTokenBalance + inputAmount;
+  const newOutputTokenBalance = computeOutputTokenBalance(
+    newInputTokenBalance,
+    inputTokenBalance,
+    outputTokenBalance,
+    ammConfig,
+  );
+  const grossOutputAmount = outputTokenBalance - newOutputTokenBalance;
+  const feeAmount = (grossOutputAmount * ammConfig.fee) / ammConfig.feeDenominator;
+  const adminFeeAmount = (feeAmount * ammConfig.adminFee) / ammConfig.feeDenominator;
+  const netOutputAmount = grossOutputAmount - feeAmount;
+  const newOutputStableTokenBalance = newOutputTokenBalance + (feeAmount - adminFeeAmount);
+
+  return {
+    newInputStableTokenBalance: newInputTokenBalance,
+    newOutputStableTokenBalance,
+    grossOutputAmount,
+    feeAmount,
+    adminFeeAmount,
+    netOutputAmount,
+  };
+}
+
+export function calculateExchangeNetOutputAmount(input: ExchangeQuoteInput, config?: AmmMathConfig): bigint {
+  return calculateExchangeQuote(input, config).netOutputAmount;
+}
+
+export function calculateAddLiquidityQuote(
+  {
+    stableToken1Amount,
+    stableToken2Amount,
+    stableToken1Balance,
+    stableToken2Balance,
+    lpTokenSupply,
+  }: AddLiquidityQuoteInput,
+  config?: AmmMathConfig,
+): AddLiquidityQuote {
+  const ammConfig = resolveAmmMathConfig(config);
+
+  assertU128("stableToken1Amount", stableToken1Amount);
+  assertU128("stableToken2Amount", stableToken2Amount);
+  assertU128("stableToken1Balance", stableToken1Balance);
+  assertU128("stableToken2Balance", stableToken2Balance);
+  assertU128("lpTokenSupply", lpTokenSupply);
+
+  const balancesBefore: PoolBalances = [stableToken1Balance, stableToken2Balance];
+  const invariantBefore = lpTokenSupply > 0n ? computeInvariant(balancesBefore, ammConfig) : 0n;
+
+  const balancesAfterDeposit: [bigint, bigint] = [
+    stableToken1Balance + stableToken1Amount,
+    stableToken2Balance + stableToken2Amount,
+  ];
+  const invariantAfterDeposit = computeInvariant(balancesAfterDeposit, ammConfig);
+
+  if (invariantAfterDeposit <= invariantBefore) {
+    throw new Error("invariant_after_deposit must be greater than invariant_before");
+  }
+
+  if (lpTokenSupply === 0n) {
+    if (stableToken1Amount === 0n || stableToken2Amount === 0n) {
+      throw new Error("initial liquidity must deposit non-zero amounts for both tokens");
+    }
+
+    return {
+      invariantBefore,
+      invariantAfterDeposit,
+      invariantAfterFee: invariantAfterDeposit,
+      balancesAfterDeposit,
+      balancesAfterFee: balancesAfterDeposit,
+      stableToken1Fee: 0n,
+      stableToken2Fee: 0n,
+      newStableToken1Balance: balancesAfterDeposit[0],
+      newStableToken2Balance: balancesAfterDeposit[1],
+      mintAmount: invariantAfterDeposit,
+    };
+  }
+
+  const feePerToken = ammConfig.fee / 2n;
+
+  let idealBalance = (invariantAfterDeposit * stableToken1Balance) / invariantBefore;
+  const stableToken1Fee =
+    (feePerToken * absoluteDifference(idealBalance, balancesAfterDeposit[0])) / ammConfig.feeDenominator;
+  const newStableToken1Balance =
+    balancesAfterDeposit[0] - (stableToken1Fee * ammConfig.adminFee) / ammConfig.feeDenominator;
+
+  idealBalance = (invariantAfterDeposit * stableToken2Balance) / invariantBefore;
+  const stableToken2Fee =
+    (feePerToken * absoluteDifference(idealBalance, balancesAfterDeposit[1])) / ammConfig.feeDenominator;
+  const newStableToken2Balance =
+    balancesAfterDeposit[1] - (stableToken2Fee * ammConfig.adminFee) / ammConfig.feeDenominator;
+
+  const balancesAfterFee: [bigint, bigint] = [
+    balancesAfterDeposit[0] - stableToken1Fee,
+    balancesAfterDeposit[1] - stableToken2Fee,
+  ];
+  const invariantAfterFee = computeInvariant(balancesAfterFee, ammConfig);
+  const mintAmount = (lpTokenSupply * (invariantAfterFee - invariantBefore)) / invariantBefore;
+
+  return {
+    invariantBefore,
+    invariantAfterDeposit,
+    invariantAfterFee,
+    balancesAfterDeposit,
+    balancesAfterFee,
+    stableToken1Fee,
+    stableToken2Fee,
+    newStableToken1Balance,
+    newStableToken2Balance,
+    mintAmount,
+  };
+}
+
+export function calculateAddLiquidityMintAmount(input: AddLiquidityQuoteInput, config?: AmmMathConfig): bigint {
+  return calculateAddLiquidityQuote(input, config).mintAmount;
+}
+
+export function calculateRemoveLiquidityQuote({
+  lpTokenAmount,
+  stableToken1Balance,
+  stableToken2Balance,
+  lpTokenSupply,
+}: RemoveLiquidityQuoteInput): RemoveLiquidityQuote {
+  assertU128("lpTokenAmount", lpTokenAmount);
+  assertU128("stableToken1Balance", stableToken1Balance);
+  assertU128("stableToken2Balance", stableToken2Balance);
+  assertU128("lpTokenSupply", lpTokenSupply);
+  assertPositive("lpTokenSupply", lpTokenSupply);
+
+  const stableToken1Amount = (stableToken1Balance * lpTokenAmount) / lpTokenSupply;
+  const stableToken2Amount = (stableToken2Balance * lpTokenAmount) / lpTokenSupply;
+
+  return {
+    stableToken1Amount,
+    stableToken2Amount,
+    newStableToken1Balance: stableToken1Balance - stableToken1Amount,
+    newStableToken2Balance: stableToken2Balance - stableToken2Amount,
+  };
+}
+
+export function calculateRemoveLiquidityOutputAmounts(input: RemoveLiquidityQuoteInput): [bigint, bigint] {
+  const { stableToken1Amount, stableToken2Amount } = calculateRemoveLiquidityQuote(input);
+  return [stableToken1Amount, stableToken2Amount];
+}

--- a/packages/policy-engine-sdk/src/amm-pool.ts
+++ b/packages/policy-engine-sdk/src/amm-pool.ts
@@ -1,4 +1,4 @@
-const DEFAULT_MAX_ITERATIONS = 12;
+const DEFAULT_MAX_ITERATIONS = 9;
 const DEFAULT_AMPLIFICATION = 85n;
 const MAX_U128 = (1n << 128n) - 1n;
 
@@ -159,7 +159,7 @@ export function computeInvariant(tokenBalances: PoolBalances, config?: AmmMathCo
     const previousInvariant = invariant;
     invariant =
       ((ammConfig.ann * totalBalance + productTerm * 2n) * invariant) /
-      ((ammConfig.ann - 1n) * invariant + 3n * productTerm);
+      ((ammConfig.ann - 1n) * invariant + 3n * productTerm + 1n);
 
     if (absoluteDifference(invariant, previousInvariant) <= 1n) {
       return invariant;

--- a/packages/policy-engine-sdk/src/index.ts
+++ b/packages/policy-engine-sdk/src/index.ts
@@ -14,6 +14,17 @@
 export { PolicyEngine } from "./policy-engine.js";
 export { AleoAPIClient } from "./api-client.js";
 export { buildTree, generateLeaves, getLeafIndices, getSiblingPath } from "./merkle-tree.js";
+export {
+  DEFAULT_AMM_MATH_CONFIG,
+  computeInvariant,
+  computeOutputTokenBalance,
+  calculateExchangeQuote,
+  calculateExchangeNetOutputAmount,
+  calculateAddLiquidityQuote,
+  calculateAddLiquidityMintAmount,
+  calculateRemoveLiquidityQuote,
+  calculateRemoveLiquidityOutputAmounts,
+} from "./amm-pool.js";
 export { convertAddressToField, convertFieldToAddress, stringToBigInt } from "./conversion.js";
 export { defaultLogger, silentLogger } from "./logger.js";
 export { trackTransactionStatus } from "./transaction-tracker.js";
@@ -30,4 +41,15 @@ export type {
   TransactionType,
   TransactionTrackingOptions,
 } from "./types.js";
+export type {
+  AmmFeesConfig,
+  AmmMathConfig,
+  ResolvedAmmMathConfig,
+  ExchangeQuoteInput,
+  ExchangeQuote,
+  AddLiquidityQuoteInput,
+  AddLiquidityQuote,
+  RemoveLiquidityQuoteInput,
+  RemoveLiquidityQuote,
+} from "./amm-pool.js";
 export type { Logger, LogLevel } from "./logger.js";

--- a/packages/policy-engine-sdk/test/amm-pool.test.ts
+++ b/packages/policy-engine-sdk/test/amm-pool.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, test } from "vitest";
+import {
+  DEFAULT_AMM_MATH_CONFIG,
+  type AddLiquidityQuoteInput,
+  type ExchangeQuoteInput,
+  calculateAddLiquidityMintAmount,
+  calculateExchangeNetOutputAmount,
+  computeInvariant,
+} from "../src/amm-pool.js";
+
+const REFERENCE_MAX_ITERATIONS = 256;
+
+const RESERVE_PAIRS: ReadonlyArray<readonly [bigint, bigint]> = [
+  [1_000n, 1_000n],
+  [10_000n, 10_000n],
+  [1_000_000n, 1_000_000n],
+  [1_000_000n, 500_000n],
+  [500_000n, 1_000_000n],
+  [1_000_000_000n, 1_000_000_000n],
+  [1_000_000_000n, 1_500_000_000n],
+  [1_000_000_000_000_000n, 1_000_000_000_000_000n],
+  [1_000_000_000_000_000n, 950_000_000_000_000n],
+];
+
+const INPUT_DIVISORS = [100_000n, 10_000n, 1_000n, 100n, 10n, 1n] as const;
+
+interface ScenarioMeasurement {
+  scenario: ExchangeQuoteInput;
+  referenceOutput: bigint;
+  requiredMaxIterations: number;
+}
+
+interface AddLiquidityMeasurement {
+  scenario: AddLiquidityQuoteInput;
+  referenceMintAmount: bigint;
+  requiredMaxIterations: number;
+}
+
+function formatScenario({ inputAmount, inputTokenBalance, outputTokenBalance }: ExchangeQuoteInput): string {
+  return `input=${inputAmount.toString()} in=${inputTokenBalance.toString()} out=${outputTokenBalance.toString()}`;
+}
+
+function formatAddLiquidityScenario({
+  stableToken1Amount,
+  stableToken2Amount,
+  stableToken1Balance,
+  stableToken2Balance,
+  lpTokenSupply,
+}: AddLiquidityQuoteInput): string {
+  return [
+    `deposit1=${stableToken1Amount.toString()}`,
+    `deposit2=${stableToken2Amount.toString()}`,
+    `balance1=${stableToken1Balance.toString()}`,
+    `balance2=${stableToken2Balance.toString()}`,
+    `lpSupply=${lpTokenSupply.toString()}`,
+  ].join(" ");
+}
+
+function scaledAmount(value: bigint, divisor: bigint): bigint {
+  const scaled = value / divisor;
+  return scaled > 0n ? scaled : 1n;
+}
+
+function buildExchangeScenarios(): ExchangeQuoteInput[] {
+  const scenarios: ExchangeQuoteInput[] = [];
+
+  for (const [inputTokenBalance, outputTokenBalance] of RESERVE_PAIRS) {
+    const inputs = new Set<bigint>([1n, 2n, 10n, inputTokenBalance, inputTokenBalance * 2n]);
+
+    for (const divisor of INPUT_DIVISORS) {
+      const scaledInput = inputTokenBalance / divisor;
+      if (scaledInput > 0n) {
+        inputs.add(scaledInput);
+      }
+    }
+
+    for (const inputAmount of inputs) {
+      scenarios.push({
+        inputAmount,
+        inputTokenBalance,
+        outputTokenBalance,
+      });
+    }
+  }
+
+  return scenarios;
+}
+
+function buildAddLiquidityScenarios(): AddLiquidityQuoteInput[] {
+  const scenarios: AddLiquidityQuoteInput[] = [];
+
+  for (const [stableToken1Balance, stableToken2Balance] of RESERVE_PAIRS) {
+    const lpTokenSupply = computeInvariant([stableToken1Balance, stableToken2Balance], {
+      maxIterations: REFERENCE_MAX_ITERATIONS,
+    });
+
+    const depositPairs = new Map<string, readonly [bigint, bigint]>();
+    const candidateDeposits: ReadonlyArray<readonly [bigint, bigint]> = [
+      [1n, 1n],
+      [10n, 10n],
+      [scaledAmount(stableToken1Balance, 1_000n), scaledAmount(stableToken2Balance, 1_000n)],
+      [scaledAmount(stableToken1Balance, 100n), scaledAmount(stableToken2Balance, 100n)],
+      [scaledAmount(stableToken1Balance, 10n), scaledAmount(stableToken2Balance, 10n)],
+      [scaledAmount(stableToken1Balance, 100n), scaledAmount(stableToken2Balance, 200n)],
+      [scaledAmount(stableToken1Balance, 200n), scaledAmount(stableToken2Balance, 100n)],
+    ];
+
+    for (const [stableToken1Amount, stableToken2Amount] of candidateDeposits) {
+      depositPairs.set(`${stableToken1Amount.toString()}:${stableToken2Amount.toString()}`, [
+        stableToken1Amount,
+        stableToken2Amount,
+      ]);
+    }
+
+    for (const [stableToken1Amount, stableToken2Amount] of depositPairs.values()) {
+      scenarios.push({
+        stableToken1Amount,
+        stableToken2Amount,
+        stableToken1Balance,
+        stableToken2Balance,
+        lpTokenSupply,
+      });
+    }
+  }
+
+  scenarios.push(
+    {
+      stableToken1Amount: 1_000n,
+      stableToken2Amount: 1_000n,
+      stableToken1Balance: 0n,
+      stableToken2Balance: 0n,
+      lpTokenSupply: 0n,
+    },
+    {
+      stableToken1Amount: 1_000_000n,
+      stableToken2Amount: 1_000_000n,
+      stableToken1Balance: 0n,
+      stableToken2Balance: 0n,
+      lpTokenSupply: 0n,
+    },
+    {
+      stableToken1Amount: 1_000_000_000_000_000n,
+      stableToken2Amount: 950_000_000_000_000n,
+      stableToken1Balance: 0n,
+      stableToken2Balance: 0n,
+      lpTokenSupply: 0n,
+    },
+  );
+
+  return scenarios;
+}
+
+function measureScenario(scenario: ExchangeQuoteInput): ScenarioMeasurement {
+  const referenceOutput = calculateExchangeNetOutputAmount(scenario, {
+    maxIterations: REFERENCE_MAX_ITERATIONS,
+  });
+
+  for (let maxIterations = 0; maxIterations <= REFERENCE_MAX_ITERATIONS; maxIterations++) {
+    const candidateOutput = calculateExchangeNetOutputAmount(scenario, { maxIterations });
+    if (candidateOutput === referenceOutput) {
+      return {
+        scenario,
+        referenceOutput,
+        requiredMaxIterations: maxIterations,
+      };
+    }
+  }
+
+  throw new Error(`No matching maxIterations found for ${formatScenario(scenario)}`);
+}
+
+function measureAddLiquidityScenario(scenario: AddLiquidityQuoteInput): AddLiquidityMeasurement {
+  const referenceMintAmount = calculateAddLiquidityMintAmount(scenario, {
+    maxIterations: REFERENCE_MAX_ITERATIONS,
+  });
+
+  for (let maxIterations = 0; maxIterations <= REFERENCE_MAX_ITERATIONS; maxIterations++) {
+    const candidateMintAmount = calculateAddLiquidityMintAmount(scenario, { maxIterations });
+    if (candidateMintAmount === referenceMintAmount) {
+      return {
+        scenario,
+        referenceMintAmount,
+        requiredMaxIterations: maxIterations,
+      };
+    }
+  }
+
+  throw new Error(`No matching maxIterations found for ${formatAddLiquidityScenario(scenario)}`);
+}
+
+const EXCHANGE_SCENARIOS = buildExchangeScenarios();
+const ADD_LIQUIDITY_SCENARIOS = buildAddLiquidityScenarios();
+
+describe("amm pool exchange math", () => {
+  test("default maxIterations matches the 256-iteration reference across representative exchange scenarios", () => {
+    for (const scenario of EXCHANGE_SCENARIOS) {
+      const referenceOutput = calculateExchangeNetOutputAmount(scenario, {
+        maxIterations: REFERENCE_MAX_ITERATIONS,
+      });
+      const defaultOutput = calculateExchangeNetOutputAmount(scenario);
+
+      expect(defaultOutput, `default maxIterations diverged for ${formatScenario(scenario)}`).toBe(referenceOutput);
+    }
+  });
+
+  test("measures the minimum maxIterations needed to match the 256-iteration reference", () => {
+    const measurements = EXCHANGE_SCENARIOS.map(measureScenario);
+    const worstCase = measurements.reduce((currentWorst, measurement) =>
+      measurement.requiredMaxIterations > currentWorst.requiredMaxIterations ? measurement : currentWorst,
+    );
+
+    console.info(
+      [
+        "calculateExchangeNetOutputAmount minimum maxIterations against 256-iteration reference:",
+        `required=${worstCase.requiredMaxIterations}`,
+        `default=${DEFAULT_AMM_MATH_CONFIG.maxIterations}`,
+        `scenario=${formatScenario(worstCase.scenario)}`,
+        `reference=${worstCase.referenceOutput.toString()}`,
+      ].join(" "),
+    );
+
+    expect(worstCase.requiredMaxIterations).toBeLessThanOrEqual(DEFAULT_AMM_MATH_CONFIG.maxIterations);
+
+    if (worstCase.requiredMaxIterations > 0) {
+      const previousOutput = calculateExchangeNetOutputAmount(worstCase.scenario, {
+        maxIterations: worstCase.requiredMaxIterations - 1,
+      });
+      expect(previousOutput).not.toBe(worstCase.referenceOutput);
+    }
+  });
+});
+
+describe("amm pool add_liquidity math", () => {
+  test("default maxIterations matches the 256-iteration reference across representative add_liquidity scenarios", () => {
+    for (const scenario of ADD_LIQUIDITY_SCENARIOS) {
+      const referenceMintAmount = calculateAddLiquidityMintAmount(scenario, {
+        maxIterations: REFERENCE_MAX_ITERATIONS,
+      });
+      const defaultMintAmount = calculateAddLiquidityMintAmount(scenario);
+
+      expect(defaultMintAmount, `default maxIterations diverged for ${formatAddLiquidityScenario(scenario)}`).toBe(
+        referenceMintAmount,
+      );
+    }
+  });
+
+  test("measures the minimum maxIterations needed for calculateAddLiquidityMintAmount to match the 256-iteration reference", () => {
+    const measurements = ADD_LIQUIDITY_SCENARIOS.map(measureAddLiquidityScenario);
+    const worstCase = measurements.reduce((currentWorst, measurement) =>
+      measurement.requiredMaxIterations > currentWorst.requiredMaxIterations ? measurement : currentWorst,
+    );
+
+    console.info(
+      [
+        "calculateAddLiquidityMintAmount minimum maxIterations against 256-iteration reference:",
+        `required=${worstCase.requiredMaxIterations}`,
+        `default=${DEFAULT_AMM_MATH_CONFIG.maxIterations}`,
+        `scenario=${formatAddLiquidityScenario(worstCase.scenario)}`,
+        `reference=${worstCase.referenceMintAmount.toString()}`,
+      ].join(" "),
+    );
+
+    expect(worstCase.requiredMaxIterations).toBeLessThanOrEqual(DEFAULT_AMM_MATH_CONFIG.maxIterations);
+
+    if (worstCase.requiredMaxIterations > 0) {
+      const previousMintAmount = calculateAddLiquidityMintAmount(worstCase.scenario, {
+        maxIterations: worstCase.requiredMaxIterations - 1,
+      });
+      expect(previousMintAmount).not.toBe(worstCase.referenceMintAmount);
+    }
+  });
+});

--- a/programs/amm/amm_pool.leo
+++ b/programs/amm/amm_pool.leo
@@ -1,0 +1,514 @@
+import multisig_core.aleo;
+import lp_token.aleo;
+import stable_token_1.aleo;
+import stable_token_2.aleo;
+
+program amm_pool.aleo {
+    @custom
+    async constructor() {
+        // Only require multisig for upgrades - initial deployment has no checks.
+        if self.edition > 0u16 {
+            let signing_op_id = BHP256::hash_to_field(ChecksumEdition { checksum: self.checksum, edition: self.edition });
+
+            let wallet_signing_op_id_hash = BHP256::hash_to_field(multisig_core.aleo/WalletSigningOpId { wallet_id: self.address, signing_op_id: signing_op_id });
+            let signing_complete = multisig_core.aleo/completed_signing_ops.contains(wallet_signing_op_id_hash);
+            assert(signing_complete);
+        }
+    }
+
+    struct ChecksumEdition {
+        checksum: [u8; 32],
+        edition: u16,
+    }
+
+    const MAX_ITERATIONS: u8 = 12u8;
+    const AMPLIFICATION: u128 = 85u128;
+    const ANN: u128 = AMPLIFICATION * 2u128; // amplification * number of coins
+
+    const FEE: u128 = 6_000_000u128;        // 0.06% = 0.0006 * 1e10
+    const ADMIN_FEE: u128 = 0u128;          // 0%
+    const FEE_DENOMINATOR: u128 = 10_000_000_000u128;
+
+    const ADMIN_ADDRESS: address = aleo1mh7al4qsedqvsh64pmmlcmzl5ugmrdxp4a4rdneja7etn8cpuspqvrj9q8;
+
+    record Stable_Token_1_Voucher {
+        owner: address,
+        voucher_id: field,
+    }
+    record Stable_Token_2_Voucher {
+        owner: address,
+        voucher_id: field,
+    }
+    record LP_Voucher {
+        owner: address,
+        voucher_id: field,
+    }
+
+    const INITIALIZED_INDEX: bool = true;
+    mapping initialized: bool => bool;
+    
+    mapping vouchers: field => u128; // voucher_id => remaining amount
+    storage stable_token_1_balance: u128;   // Accounted balance used in AMM invariant (excludes reserved)
+    storage stable_token_2_balance: u128;   // Accounted balance used in AMM invariant (excludes reserved)
+
+    storage stable_token_1_reserved: u128;  // Amount reserved for unredeemed vouchers (not available for swaps)
+    storage stable_token_2_reserved: u128;  // Amount reserved for unredeemed vouchers (not available for swaps)
+    storage lp_token_reserved: u128;   // Amount reserved for unredeemed vouchers (not available for swaps)
+
+    async transition initialize() -> Future {
+        return finalize_initialize(self.caller);
+    }
+    async function finalize_initialize(caller: address) {
+        assert_eq(ADMIN_ADDRESS, caller);
+        
+        let is_already_initialized: bool = initialized.get_or_use(INITIALIZED_INDEX, false);
+        assert_eq(is_already_initialized, false);
+        
+        initialized.set(INITIALIZED_INDEX, true);
+
+        stable_token_1_balance = 0u128;
+        stable_token_2_balance = 0u128;
+        stable_token_1_reserved = 0u128;
+        stable_token_2_reserved = 0u128;
+        lp_token_reserved = 0u128;
+
+        /*
+        initialize the lp token?
+        */
+    }
+
+    async transition add_liquidity(
+        stable_token_1_amount: u128,
+        stable_token_2_amount: u128,
+        stable_token_1_record: stable_token_1.aleo/Token,
+        stable_token_2_record: stable_token_2.aleo/Token,
+        min_mint_amount: u128,
+        stable_token_1_merkle_proof: [stable_token_1.aleo/MerkleProof; 2],
+        stable_token_2_merkle_proof: [stable_token_2.aleo/MerkleProof; 2], 
+        voucher_id: field,
+    ) -> (stable_token_1.aleo/Token, stable_token_2.aleo/Token, lp_token.aleo/Token, LP_Voucher, Future) {
+        let transfer_stable_token_1: (stable_token_1.aleo/ComplianceRecord, stable_token_1.aleo/Token, Future) = stable_token_1.aleo/transfer_private_to_public(
+            self.address,
+            stable_token_1_amount,
+            stable_token_1_record,
+            stable_token_1_merkle_proof
+        );
+        let transfer_stable_token_2: (stable_token_2.aleo/ComplianceRecord, stable_token_2.aleo/Token, Future) = stable_token_2.aleo/transfer_private_to_public(
+            self.address,
+            stable_token_2_amount,
+            stable_token_2_record,
+            stable_token_2_merkle_proof
+        );
+
+        let mint_lp_token: (lp_token.aleo/ComplianceRecord, lp_token.aleo/Token, Future) = lp_token.aleo/mint_private(self.signer, min_mint_amount);
+        
+        let lp_voucher_record = LP_Voucher {
+            owner: self.signer,
+            voucher_id: voucher_id
+        };
+
+        return (
+            transfer_stable_token_1.1,
+            transfer_stable_token_2.1,
+            mint_lp_token.1,
+            lp_voucher_record,
+            finalize_add_liquidity(
+                stable_token_1_amount,
+                stable_token_2_amount,
+                voucher_id,
+                min_mint_amount,
+                transfer_stable_token_1.2,
+                transfer_stable_token_2.2,
+                mint_lp_token.2,
+            )
+        );
+    }
+    async function finalize_add_liquidity(
+        stable_token_1_amount: u128,
+        stable_token_2_amount: u128,
+        voucher_id: field,
+        min_mint_amount: u128,
+        transfer_stable_token_1: Future,
+        transfer_stable_token_2: Future,
+        mint_lp_token: Future
+    ) {
+        // the total lp token should include the vouchers
+        let token_info = lp_token.aleo/token_info.get(true);
+        let token_supply =  token_info.supply + lp_token_reserved.unwrap();
+
+        let balances_before: [u128; 2] = [stable_token_1_balance.unwrap(), stable_token_2_balance.unwrap()];
+        let invariant_before: u128 = token_supply > 0 ? compute_invariant(balances_before) : 0u128; // initial_invariant
+
+        let balances_after_deposit: [u128; 2] = [balances_before[0] + stable_token_1_amount, balances_before[1] + stable_token_2_amount];
+
+        //Invariant after change
+        let invariant_after_deposit: u128 = compute_invariant(balances_after_deposit);
+        assert(invariant_after_deposit > invariant_before);
+
+        // # Calculate, how much lp tokens to mint
+
+        let voucher_exists = vouchers.contains(voucher_id);
+        assert_eq(voucher_exists, false);
+
+        if (token_supply == 0) {
+            assert_neq(stable_token_1_amount, 0u128);
+            assert_neq(stable_token_2_amount, 0u128);
+            stable_token_1_balance = balances_after_deposit[0];
+            stable_token_2_balance = balances_after_deposit[1];
+            let mint_amount: u128 =  invariant_after_deposit;
+
+            let voucher_amount = mint_amount - min_mint_amount;
+            vouchers.set(voucher_id, voucher_amount);
+            lp_token_reserved = lp_token_reserved.unwrap() + voucher_amount;
+        } else {
+            // We need to recalculate the invariant accounting for fees
+            // to calculate fair user's share
+            // Only account for fees if we are not the first to deposit
+            let fee_per_token: u128 = FEE / 2;
+            let ideal_balance: u128 = invariant_after_deposit * balances_before[0] / invariant_before;
+            let difference: u128 = ideal_balance > balances_after_deposit[0] ? ideal_balance - balances_after_deposit[0] : balances_after_deposit[0] - ideal_balance;
+            let stable_token_1_fee: u128 = fee_per_token * difference / FEE_DENOMINATOR;
+            stable_token_1_balance = balances_after_deposit[0] - stable_token_1_fee * ADMIN_FEE / FEE_DENOMINATOR;
+            ideal_balance = invariant_after_deposit * balances_before[1] / invariant_before;
+            difference = ideal_balance > balances_after_deposit[1] ? ideal_balance - balances_after_deposit[1] : balances_after_deposit[1] - ideal_balance;
+            let stable_token_2_fee: u128 = fee_per_token * difference / FEE_DENOMINATOR;
+            stable_token_2_balance = balances_after_deposit[1] - stable_token_2_fee * ADMIN_FEE / FEE_DENOMINATOR;
+            let balances_after_fee: [u128; 2] = [balances_after_deposit[0] - stable_token_1_fee, balances_after_deposit[1] - stable_token_2_fee];
+            let invariant_after_fee: u128 = compute_invariant(balances_after_fee);
+            let mint_amount: u128 = token_supply * (invariant_after_fee - invariant_before) / invariant_before;
+
+            let voucher_amount = mint_amount - min_mint_amount;
+            vouchers.set(voucher_id, voucher_amount);
+
+            lp_token_reserved = lp_token_reserved.unwrap() + voucher_amount;
+        }
+
+        transfer_stable_token_1.await();
+        transfer_stable_token_2.await();
+        mint_lp_token.await();
+    }
+
+    async transition remove_liquidity(
+        lp_token_amount: u128, 
+        min_stable_token_1_amount: u128, 
+        min_stable_token_2_amount: u128,
+        lp_token_record: lp_token.aleo/Token,
+        stable_token_1_voucher_id: field,
+        stable_token_2_voucher_id: field,
+    ) -> (lp_token.aleo/Token, stable_token_1.aleo/Token, stable_token_2.aleo/Token, Stable_Token_1_Voucher, Stable_Token_2_Voucher, Future) {
+        let burn_lp_token: (lp_token.aleo/ComplianceRecord, lp_token.aleo/Token, Future) = lp_token.aleo/burn_private(lp_token_record, lp_token_amount);
+        let transfer_stable_token_1: (stable_token_1.aleo/ComplianceRecord, stable_token_1.aleo/Token, Future) = stable_token_1.aleo/transfer_public_to_private(lp_token_record.owner, min_stable_token_1_amount);
+        let transfer_stable_token_2: (stable_token_2.aleo/ComplianceRecord, stable_token_2.aleo/Token, Future) = stable_token_2.aleo/transfer_public_to_private(lp_token_record.owner, min_stable_token_2_amount);    
+
+        let stable_coin_1_voucher = Stable_Token_1_Voucher {
+            owner: lp_token_record.owner,
+            voucher_id: stable_token_1_voucher_id
+        };
+
+        let stable_coin_2_voucher = Stable_Token_2_Voucher {
+            owner: lp_token_record.owner,
+            voucher_id: stable_token_2_voucher_id
+        };
+        return (
+            burn_lp_token.1,
+            transfer_stable_token_1.1,
+            transfer_stable_token_2.1,
+            stable_coin_1_voucher,
+            stable_coin_2_voucher,
+            finalize_remove_liquidity(
+                lp_token_amount,
+                min_stable_token_1_amount,
+                min_stable_token_2_amount,
+                stable_token_1_voucher_id,
+                stable_token_2_voucher_id,
+                burn_lp_token.2,
+                transfer_stable_token_1.2,
+                transfer_stable_token_2.2
+            )
+        );
+    }
+
+    async function finalize_remove_liquidity(
+        lp_token_amount: u128, 
+        min_stable_token_1_amount: u128, 
+        min_stable_token_2_amount: u128,
+        stable_token_1_voucher_id: field,
+        stable_token_2_voucher_id: field,
+        burn_lp_token: Future,
+        transfer_stable_token_1: Future,
+        transfer_stable_token_2: Future,
+    ) {
+        let token_info = lp_token.aleo/token_info.get(true);
+        let token_supply =  token_info.supply + lp_token_reserved.unwrap();
+
+        let amount_token_1: u128 = stable_token_1_balance.unwrap() * lp_token_amount / token_supply;
+        stable_token_1_balance = stable_token_1_balance.unwrap() - amount_token_1;
+        let voucher_1_exists = vouchers.contains(stable_token_1_voucher_id);
+        assert_eq(voucher_1_exists, false);
+        let stable_token_1_voucher_amount = amount_token_1 - min_stable_token_1_amount;
+        vouchers.set(stable_token_1_voucher_id, stable_token_1_voucher_amount);
+        stable_token_1_reserved = stable_token_1_reserved.unwrap() + stable_token_1_voucher_amount;
+
+        let amount_token_2: u128 = stable_token_2_balance.unwrap() * lp_token_amount / token_supply;
+        stable_token_2_balance = stable_token_2_balance.unwrap() - amount_token_2;
+        let voucher_2_exists = vouchers.contains(stable_token_2_voucher_id);
+        assert_eq(voucher_2_exists, false);
+        let stable_token_2_voucher_amount = amount_token_2 - min_stable_token_2_amount;
+        vouchers.set(stable_token_2_voucher_id, stable_token_2_voucher_amount);
+        stable_token_2_reserved = stable_token_2_reserved.unwrap() + stable_token_2_voucher_amount;
+
+        burn_lp_token.await();
+        transfer_stable_token_1.await();
+        transfer_stable_token_2.await();
+    }
+    
+
+    async transition exchange_1_for_2(
+        input_amount: u128,
+        min_output_amount: u128,
+        input_record: stable_token_1.aleo/Token,
+        merkle_proof: [stable_token_1.aleo/MerkleProof;2],
+        voucher_id: field
+    ) -> (stable_token_1.aleo/Token, stable_token_2.aleo/Token, Stable_Token_2_Voucher, Future) {
+        let transfer_input_token: (stable_token_1.aleo/ComplianceRecord, stable_token_1.aleo/Token, Future) = stable_token_1.aleo/transfer_private_to_public(
+            self.address,
+            input_amount,
+            input_record,
+            merkle_proof
+        );
+        let transfer_output_token: (stable_token_2.aleo/ComplianceRecord, stable_token_2.aleo/Token, Future) = stable_token_2.aleo/transfer_public_to_private(
+            input_record.owner,
+            min_output_amount,
+        );
+
+        let voucher = Stable_Token_2_Voucher {
+            owner: input_record.owner,
+            voucher_id: voucher_id
+        };
+
+        return (
+            transfer_input_token.1, // input token record leftover
+            transfer_output_token.1, // output token record
+            voucher,
+            finalize_exchange_1_for_2(input_amount, min_output_amount, voucher_id, transfer_input_token.2, transfer_output_token.2)
+        );
+    }
+
+    async function finalize_exchange_1_for_2(
+        input_amount: u128,
+        min_output_amount: u128,
+        voucher_id: field,
+        transfer_input_token: Future,
+        transfer_output_token: Future
+    ) {
+        let input_token_balance = stable_token_1_balance.unwrap();
+        let output_token_balance = stable_token_2_balance.unwrap();
+        let new_input_token_balance: u128 = input_token_balance + input_amount;
+        let new_output_token_balance: u128 = compute_output_token_balance(new_input_token_balance, input_token_balance, output_token_balance);
+        let gross_output_amount: u128 = output_token_balance - new_output_token_balance;
+
+        let fee_amount: u128 = gross_output_amount * FEE / FEE_DENOMINATOR;
+        let admin_fee_amount: u128 = fee_amount * ADMIN_FEE / FEE_DENOMINATOR;
+
+        stable_token_1_balance = new_input_token_balance;
+        stable_token_2_balance = new_output_token_balance + (fee_amount - admin_fee_amount);
+
+        let net_output_amount: u128 = gross_output_amount - fee_amount;
+
+        let voucher_exists = vouchers.contains(voucher_id);
+        assert_eq(voucher_exists, false);
+        let voucher_amount = net_output_amount - min_output_amount;
+        vouchers.set(voucher_id, voucher_amount);
+        stable_token_2_reserved = stable_token_2_reserved.unwrap() + voucher_amount;
+
+        transfer_input_token.await();
+        transfer_output_token.await();
+    }
+
+        async transition exchange_2_for_1(
+        input_amount: u128,
+        min_output_amount: u128,
+        input_record: stable_token_2.aleo/Token,
+        merkle_proof: [stable_token_2.aleo/MerkleProof;2],
+        voucher_id: field
+    ) -> (stable_token_2.aleo/Token, stable_token_1.aleo/Token, Stable_Token_1_Voucher, Future) {
+        let transfer_input_token: (stable_token_2.aleo/ComplianceRecord, stable_token_2.aleo/Token, Future) = stable_token_2.aleo/transfer_private_to_public(
+            self.address,
+            input_amount,
+            input_record,
+            merkle_proof
+        );
+        let transfer_output_token: (stable_token_1.aleo/ComplianceRecord, stable_token_1.aleo/Token, Future) = stable_token_1.aleo/transfer_public_to_private(
+            input_record.owner,
+            min_output_amount,
+        );
+
+        let voucher = Stable_Token_1_Voucher {
+            owner: input_record.owner,
+            voucher_id: voucher_id
+        };
+
+        return (
+            transfer_input_token.1, // input token record leftover
+            transfer_output_token.1, // output token record
+            voucher,
+            finalize_exchange_2_for_1(input_amount, min_output_amount, voucher_id, transfer_input_token.2, transfer_output_token.2)
+        );
+    }
+
+    async function finalize_exchange_2_for_1(
+        input_amount: u128,
+        min_output_amount: u128,
+        voucher_id: field,
+        transfer_input_token: Future,
+        transfer_output_token: Future
+    ) {
+        let input_token_balance = stable_token_2_balance.unwrap();
+        let output_token_balance = stable_token_1_balance.unwrap();
+        let new_input_token_balance: u128 = input_token_balance + input_amount;
+        let new_output_token_balance: u128 = compute_output_token_balance(new_input_token_balance, input_token_balance, output_token_balance);
+        let gross_output_amount: u128 = output_token_balance - new_output_token_balance;
+
+        let fee_amount: u128 = gross_output_amount * FEE / FEE_DENOMINATOR;
+        let admin_fee_amount: u128 = fee_amount * ADMIN_FEE / FEE_DENOMINATOR;
+
+        stable_token_2_balance = new_input_token_balance;
+        stable_token_1_balance = new_output_token_balance + (fee_amount - admin_fee_amount);
+
+        let net_output_amount: u128 = gross_output_amount - fee_amount;
+
+        let voucher_exists = vouchers.contains(voucher_id);
+        assert_eq(voucher_exists, false);
+        let voucher_amount = net_output_amount - min_output_amount;
+        vouchers.set(voucher_id, voucher_amount);
+        stable_token_1_reserved = stable_token_1_reserved.unwrap() + voucher_amount;
+
+        transfer_input_token.await();
+        transfer_output_token.await();
+    }
+
+    /// @dev Calculate invariant D for balances xp with amplification A, for n=2.
+    /// This matches the standard Curve StableSwap Newton iteration.
+    inline compute_invariant(token_balances: [u128;2]) -> u128 {
+        let total_balance: u128 = token_balances[0] + token_balances[1];
+        if(total_balance == 0u128) {
+            return 0u128;
+        }
+        let invariant: u128 = total_balance; 
+        for i: u8 in 0u8..MAX_ITERATIONS {
+            let product_term: u128 = invariant * invariant / (token_balances[0] * 2 + 1);  // +1 is to prevent /0
+            product_term = product_term * invariant / (token_balances[1] * 2 + 1);  // +1 is to prevent /0
+            let previous_invariant: u128 = invariant;
+            invariant = (ANN * total_balance + product_term * 2) * invariant / ((ANN - 1) * invariant + 3 * product_term);
+            if(invariant > previous_invariant) {
+                if(invariant - previous_invariant <= 1) {
+                    return invariant;
+                }
+            } else if(previous_invariant - invariant <= 1) {
+                return invariant;
+            }
+        }
+        return invariant;
+    }
+
+    /// @dev Calculate for output pool balance y given the input reserve x and invariant D,
+    /// This matches the standard Curve StableSwap Newton iteration.
+    inline compute_output_token_balance(new_input_token_balance: u128, input_token_balance: u128, output_token_balance: u128) -> u128 {
+        let token_balances: [u128;2] = [input_token_balance, output_token_balance];
+
+        let invariant = compute_invariant(token_balances);
+        let product_term: u128 = invariant;
+        product_term = product_term * invariant / (new_input_token_balance * 2);
+        product_term = product_term * invariant / (ANN * 2);
+
+        let sum_term: u128 = new_input_token_balance + invariant / ANN;
+
+        let new_output_token_balance: u128 = invariant;
+        for k in 0u8..MAX_ITERATIONS {
+            let previous_estimate: u128 = new_output_token_balance;
+            new_output_token_balance = (new_output_token_balance*new_output_token_balance + product_term) / (2 * new_output_token_balance + sum_term - invariant);
+            if  (new_output_token_balance > previous_estimate) {
+                if(new_output_token_balance - previous_estimate <= 1) {
+                    return new_output_token_balance;
+                }
+            } else if(previous_estimate - new_output_token_balance <= 1) {
+                return new_output_token_balance;
+            }
+        }
+        
+
+        return new_output_token_balance;
+    }
+
+    async transition redeem_stable_token_1_voucher(voucher: Stable_Token_1_Voucher, amount: u128) -> (stable_token_1.aleo/Token, Stable_Token_1_Voucher, Future) {
+        let transfer_call: (stable_token_1.aleo/ComplianceRecord, stable_token_1.aleo/Token, Future) = stable_token_1.aleo/transfer_public_to_private(voucher.owner, amount);
+        
+        let new_voucher = Stable_Token_1_Voucher {
+            owner: voucher.owner,
+            voucher_id: voucher.voucher_id
+        };
+
+        return (transfer_call.1, new_voucher, f_redeem_stable_token_1_voucher(voucher.voucher_id, amount, transfer_call.2));
+    }
+    async function f_redeem_stable_token_1_voucher(voucher_id: field, amount: u128, transfer_call: Future) {
+        let voucher_amount = vouchers.get(voucher_id);
+        vouchers.set(voucher_id, voucher_amount - amount);
+        stable_token_1_reserved = stable_token_1_reserved.unwrap() - amount;
+
+        transfer_call.await();
+    }
+    
+    async transition redeem_stable_token_2_voucher(voucher: Stable_Token_2_Voucher, amount: u128) -> (stable_token_2.aleo/Token, Stable_Token_2_Voucher, Future) {
+        let transfer_call: (stable_token_2.aleo/ComplianceRecord, stable_token_2.aleo/Token, Future) = stable_token_2.aleo/transfer_public_to_private(voucher.owner, amount);
+        
+        let new_voucher = Stable_Token_2_Voucher {
+            owner: voucher.owner,
+            voucher_id: voucher.voucher_id
+        };
+
+        return (transfer_call.1, new_voucher, f_redeem_stable_token_2_voucher(voucher.voucher_id, amount, transfer_call.2));
+    }
+    async function f_redeem_stable_token_2_voucher(voucher_id: field, amount: u128, transfer_call: Future) {
+        let voucher_amount = vouchers.get(voucher_id);
+        vouchers.set(voucher_id, voucher_amount - amount);
+        stable_token_2_reserved = stable_token_2_reserved.unwrap() - amount;
+
+        transfer_call.await();
+    }
+    
+    async transition redeem_lp_token_voucher(voucher: LP_Voucher, amount: u128) -> (lp_token.aleo/Token, LP_Voucher, Future) {
+        let mint_call: (lp_token.aleo/ComplianceRecord, lp_token.aleo/Token, Future) = lp_token.aleo/mint_private(voucher.owner, amount);
+        
+        let new_voucher = LP_Voucher {
+            owner: voucher.owner,
+            voucher_id: voucher.voucher_id
+        };
+
+        return (mint_call.1, new_voucher, f_redeem_lp_token_voucher(voucher.voucher_id, amount, mint_call.2));
+
+    }
+    async function f_redeem_lp_token_voucher(voucher_id: field, amount: u128, mint_call: Future) {
+        let voucher_amount = vouchers.get(voucher_id);
+        vouchers.set(voucher_id, voucher_amount - amount);
+        lp_token_reserved = lp_token_reserved.unwrap() - amount;
+
+        mint_call.await();
+    }
+
+    async transition withdraw_admin_fees(stable_token_1_amount: u128, stable_token_2_amount: u128) -> Future {
+        let transfer_stable_token_1: Future = stable_token_1.aleo/transfer_public(ADMIN_ADDRESS, stable_token_1_amount);
+        let transfer_stable_token_2: Future = stable_token_2.aleo/transfer_public(ADMIN_ADDRESS, stable_token_2_amount);
+
+        return finalize_withdraw_admin_fees(self.caller, stable_token_1_amount, stable_token_2_amount, transfer_stable_token_1, transfer_stable_token_2);
+    }
+    async function finalize_withdraw_admin_fees(caller: address, stable_token_1_amount: u128, stable_token_2_amount: u128, transfer_stable_token_1: Future, transfer_stable_token_2: Future) {
+        assert_eq(ADMIN_ADDRESS, caller);
+        let stable_token_1_info = stable_token_1.aleo/token_info.get(true);
+        assert(stable_token_1_info.supply - (stable_token_1_balance.unwrap() + stable_token_1_reserved.unwrap()) >= stable_token_1_amount);        
+        let stable_token_2_info = stable_token_2.aleo/token_info.get(true);
+        assert(stable_token_2_info.supply - (stable_token_2_balance.unwrap() + stable_token_2_reserved.unwrap()) >= stable_token_2_amount);
+
+        transfer_stable_token_1.await();
+        transfer_stable_token_2.await();
+    }
+}

--- a/programs/amm/amm_pool.leo
+++ b/programs/amm/amm_pool.leo
@@ -157,6 +157,9 @@ program amm_pool.aleo {
             stable_token_2_balance = balances_after_deposit[1];
             let mint_amount: u128 =  invariant_after_deposit;
 
+            // Validate the full LP mint amount against max_supply
+            assert(token_supply + mint_amount < token_info.max_supply);
+
             let voucher_amount = mint_amount - min_mint_amount;
             vouchers.set(voucher_id, voucher_amount);
             lp_token_reserved = lp_token_reserved.unwrap() + voucher_amount;
@@ -176,6 +179,9 @@ program amm_pool.aleo {
             let balances_after_fee: [u128; 2] = [balances_after_deposit[0] - stable_token_1_fee, balances_after_deposit[1] - stable_token_2_fee];
             let invariant_after_fee: u128 = compute_invariant(balances_after_fee);
             let mint_amount: u128 = token_supply * (invariant_after_fee - invariant_before) / invariant_before;
+
+            // Validate the full LP mint amount against max_supply
+            assert(token_supply + mint_amount < token_info.max_supply);
 
             let voucher_amount = mint_amount - min_mint_amount;
             vouchers.set(voucher_id, voucher_amount);
@@ -503,10 +509,10 @@ program amm_pool.aleo {
     }
     async function finalize_withdraw_admin_fees(caller: address, stable_token_1_amount: u128, stable_token_2_amount: u128, transfer_stable_token_1: Future, transfer_stable_token_2: Future) {
         assert_eq(ADMIN_ADDRESS, caller);
-        let stable_token_1_info = stable_token_1.aleo/token_info.get(true);
-        assert(stable_token_1_info.supply - (stable_token_1_balance.unwrap() + stable_token_1_reserved.unwrap()) >= stable_token_1_amount);        
-        let stable_token_2_info = stable_token_2.aleo/token_info.get(true);
-        assert(stable_token_2_info.supply - (stable_token_2_balance.unwrap() + stable_token_2_reserved.unwrap()) >= stable_token_2_amount);
+        let stable_token_1_pool_balance = stable_token_1.aleo/balances.get(self.address);
+        assert(stable_token_1_pool_balance - (stable_token_1_balance.unwrap() + stable_token_1_reserved.unwrap()) >= stable_token_1_amount);        
+        let stable_token_2_pool_balance = stable_token_2.aleo/balances.get(self.address);
+        assert(stable_token_2_pool_balance - (stable_token_2_balance.unwrap() + stable_token_2_reserved.unwrap()) >= stable_token_2_amount);
 
         transfer_stable_token_1.await();
         transfer_stable_token_2.await();

--- a/programs/amm/amm_pool.leo
+++ b/programs/amm/amm_pool.leo
@@ -21,7 +21,7 @@ program amm_pool.aleo {
         edition: u16,
     }
 
-    const MAX_ITERATIONS: u8 = 12u8;
+    const MAX_ITERATIONS: u8 = 9u8;
     const AMPLIFICATION: u128 = 85u128;
     const ANN: u128 = AMPLIFICATION * 2u128; // amplification * number of coins
 
@@ -137,7 +137,7 @@ program amm_pool.aleo {
         let token_supply =  token_info.supply + lp_token_reserved.unwrap();
 
         let balances_before: [u128; 2] = [stable_token_1_balance.unwrap(), stable_token_2_balance.unwrap()];
-        let invariant_before: u128 = token_supply > 0 ? compute_invariant(balances_before) : 0u128; // initial_invariant
+        let invariant_before: u128 = token_supply > 0 ? compute_invariant(balances_before) : 0u128;
 
         let balances_after_deposit: [u128; 2] = [balances_before[0] + stable_token_1_amount, balances_before[1] + stable_token_2_amount];
 
@@ -169,11 +169,11 @@ program amm_pool.aleo {
             // Only account for fees if we are not the first to deposit
             let fee_per_token: u128 = FEE / 2;
             let ideal_balance: u128 = invariant_after_deposit * balances_before[0] / invariant_before;
-            let difference: u128 = ideal_balance > balances_after_deposit[0] ? ideal_balance - balances_after_deposit[0] : balances_after_deposit[0] - ideal_balance;
+            let difference: u128 = absolute_difference(ideal_balance, balances_after_deposit[0]);
             let stable_token_1_fee: u128 = fee_per_token * difference / FEE_DENOMINATOR;
             stable_token_1_balance = balances_after_deposit[0] - stable_token_1_fee * ADMIN_FEE / FEE_DENOMINATOR;
             ideal_balance = invariant_after_deposit * balances_before[1] / invariant_before;
-            difference = ideal_balance > balances_after_deposit[1] ? ideal_balance - balances_after_deposit[1] : balances_after_deposit[1] - ideal_balance;
+            difference = absolute_difference(ideal_balance, balances_after_deposit[1]);
             let stable_token_2_fee: u128 = fee_per_token * difference / FEE_DENOMINATOR;
             stable_token_2_balance = balances_after_deposit[1] - stable_token_2_fee * ADMIN_FEE / FEE_DENOMINATOR;
             let balances_after_fee: [u128; 2] = [balances_after_deposit[0] - stable_token_1_fee, balances_after_deposit[1] - stable_token_2_fee];
@@ -267,7 +267,6 @@ program amm_pool.aleo {
         transfer_stable_token_1.await();
         transfer_stable_token_2.await();
     }
-    
 
     async transition exchange_1_for_2(
         input_amount: u128,
@@ -331,7 +330,7 @@ program amm_pool.aleo {
         transfer_output_token.await();
     }
 
-        async transition exchange_2_for_1(
+    async transition exchange_2_for_1(
         input_amount: u128,
         min_output_amount: u128,
         input_record: stable_token_2.aleo/Token,
@@ -400,17 +399,13 @@ program amm_pool.aleo {
         if(total_balance == 0u128) {
             return 0u128;
         }
-        let invariant: u128 = total_balance; 
+        let invariant: u128 = total_balance;
         for i: u8 in 0u8..MAX_ITERATIONS {
             let product_term: u128 = invariant * invariant / (token_balances[0] * 2 + 1);  // +1 is to prevent /0
             product_term = product_term * invariant / (token_balances[1] * 2 + 1);  // +1 is to prevent /0
             let previous_invariant: u128 = invariant;
-            invariant = (ANN * total_balance + product_term * 2) * invariant / ((ANN - 1) * invariant + 3 * product_term);
-            if(invariant > previous_invariant) {
-                if(invariant - previous_invariant <= 1) {
-                    return invariant;
-                }
-            } else if(previous_invariant - invariant <= 1) {
+            invariant = (ANN * total_balance + product_term * 2) * invariant / ((ANN - 1) * invariant + 3 * product_term + 1);
+            if (absolute_difference(invariant, previous_invariant) <= 1) {
                 return invariant;
             }
         }
@@ -433,11 +428,7 @@ program amm_pool.aleo {
         for k in 0u8..MAX_ITERATIONS {
             let previous_estimate: u128 = new_output_token_balance;
             new_output_token_balance = (new_output_token_balance*new_output_token_balance + product_term) / (2 * new_output_token_balance + sum_term - invariant);
-            if  (new_output_token_balance > previous_estimate) {
-                if(new_output_token_balance - previous_estimate <= 1) {
-                    return new_output_token_balance;
-                }
-            } else if(previous_estimate - new_output_token_balance <= 1) {
+            if(absolute_difference(new_output_token_balance, previous_estimate) <= 1) {
                 return new_output_token_balance;
             }
         }
@@ -516,5 +507,16 @@ program amm_pool.aleo {
 
         transfer_stable_token_1.await();
         transfer_stable_token_2.await();
+    }
+
+    inline absolute_difference(a: u128, b: u128) -> u128 {
+      let diff: i128 = a as i128 - b as i128;
+      let abs_diff: i128 = diff;
+
+      if abs_diff < 0i128 {
+          abs_diff = 0i128 - abs_diff;
+      }
+
+      return abs_diff as u128;
     }
 }

--- a/programs/amm/amm_pool.leo
+++ b/programs/amm/amm_pool.leo
@@ -3,30 +3,97 @@ import lp_token.aleo;
 import stable_token_1.aleo;
 import stable_token_2.aleo;
 
-program amm_pool.aleo {
-    @custom
-    async constructor() {
-        // Only require multisig for upgrades - initial deployment has no checks.
-        if self.edition > 0u16 {
-            let signing_op_id = BHP256::hash_to_field(ChecksumEdition { checksum: self.checksum, edition: self.edition });
+struct ChecksumEdition {
+    checksum: [u8; 32],
+    edition: u16,
+}
 
-            let wallet_signing_op_id_hash = BHP256::hash_to_field(multisig_core.aleo/WalletSigningOpId { wallet_id: self.address, signing_op_id: signing_op_id });
-            let signing_complete = multisig_core.aleo/completed_signing_ops.contains(wallet_signing_op_id_hash);
-            assert(signing_complete);
+/// @dev Calculate invariant D for balances xp with amplification A, for n=2.
+/// This matches the standard Curve StableSwap Newton iteration.
+fn compute_invariant(token_balances: [u128; 2]) -> u128 {
+    let total_balance: u128 = token_balances[0] + token_balances[1];
+    if (total_balance == 0u128) {
+        return 0u128;
+    }
+    let invariant: u128 = total_balance;
+    for i: u8 in 0u8..MAX_ITERATIONS {
+        let product_term: u128 = invariant * invariant / (token_balances[0] * 2 + 1); // +1 is to prevent /0
+        product_term = product_term * invariant / (token_balances[1] * 2 + 1); // +1 is to prevent /0
+        let previous_invariant: u128 = invariant;
+        invariant = (ANN * total_balance + product_term * 2)
+            * invariant
+            / ((ANN - 1) * invariant + 3 * product_term + 1);
+        if (absolute_difference(invariant, previous_invariant) <= 1) {
+            return invariant;
         }
     }
+    return invariant;
+}
 
-    struct ChecksumEdition {
-        checksum: [u8; 32],
-        edition: u16,
+/// @dev Calculate for output pool balance y given the input reserve x and invariant D,
+/// This matches the standard Curve StableSwap Newton iteration.
+fn compute_output_token_balance(
+    new_input_token_balance: u128,
+    input_token_balance: u128,
+    output_token_balance: u128,
+) -> u128 {
+    let token_balances: [u128; 2] = [input_token_balance, output_token_balance];
+    let invariant = compute_invariant(token_balances);
+    let product_term: u128 = invariant;
+    product_term = product_term * invariant / (new_input_token_balance * 2);
+    product_term = product_term * invariant / (ANN * 2);
+
+    let sum_term: u128 = new_input_token_balance + invariant / ANN;
+
+    let new_output_token_balance: u128 = invariant;
+    for k in 0u8..MAX_ITERATIONS {
+        let previous_estimate: u128 = new_output_token_balance;
+        new_output_token_balance = (new_output_token_balance
+            * new_output_token_balance
+            + product_term)
+            / (2 * new_output_token_balance + sum_term - invariant);
+        if (absolute_difference(new_output_token_balance, previous_estimate) <= 1) {
+            return new_output_token_balance;
+        }
+    }
+    return new_output_token_balance;
+}
+
+fn absolute_difference(a: u128, b: u128) -> u128 {
+    let diff: i128 = a as i128 - b as i128;
+    let abs_diff: i128 = diff;
+    if abs_diff < 0i128 {
+        abs_diff = 0i128 - abs_diff;
+    }
+    return abs_diff as u128;
+}
+
+program amm_pool.aleo {
+    @custom
+    constructor() {
+        // Only require multisig for upgrades - initial deployment has no checks.
+        if self.edition > 0u16 {
+            let signing_op_id = BHP256::hash_to_field(
+                ChecksumEdition { checksum: self.checksum, edition: self.edition },
+            );
+            let wallet_signing_op_id_hash = BHP256::hash_to_field(
+                multisig_core.aleo::WalletSigningOpId {
+                    wallet_id: self.address,
+                    signing_op_id: signing_op_id,
+                },
+            );
+            let signing_complete = multisig_core.aleo::completed_signing_ops
+                .contains(wallet_signing_op_id_hash);
+            assert(signing_complete);
+        }
     }
 
     const MAX_ITERATIONS: u8 = 9u8;
     const AMPLIFICATION: u128 = 85u128;
     const ANN: u128 = AMPLIFICATION * 2u128; // amplification * number of coins
 
-    const FEE: u128 = 6_000_000u128;        // 0.06% = 0.0006 * 1e10
-    const ADMIN_FEE: u128 = 0u128;          // 0%
+    const FEE: u128 = 6_000_000u128; // 0.06% = 0.0006 * 1e10
+    const ADMIN_FEE: u128 = 0u128; // 0%
     const FEE_DENOMINATOR: u128 = 10_000_000_000u128;
 
     const ADMIN_ADDRESS: address = aleo1mh7al4qsedqvsh64pmmlcmzl5ugmrdxp4a4rdneja7etn8cpuspqvrj9q8;
@@ -35,10 +102,12 @@ program amm_pool.aleo {
         owner: address,
         voucher_id: field,
     }
+
     record Stable_Token_2_Voucher {
         owner: address,
         voucher_id: field,
     }
+
     record LP_Voucher {
         owner: address,
         voucher_id: field,
@@ -46,477 +115,418 @@ program amm_pool.aleo {
 
     const INITIALIZED_INDEX: bool = true;
     mapping initialized: bool => bool;
-    
+
     mapping vouchers: field => u128; // voucher_id => remaining amount
-    storage stable_token_1_balance: u128;   // Accounted balance used in AMM invariant (excludes reserved)
-    storage stable_token_2_balance: u128;   // Accounted balance used in AMM invariant (excludes reserved)
+    storage stable_token_1_balance: u128; // Accounted balance used in AMM invariant (excludes reserved)
+    storage stable_token_2_balance: u128; // Accounted balance used in AMM invariant (excludes reserved)
 
-    storage stable_token_1_reserved: u128;  // Amount reserved for unredeemed vouchers (not available for swaps)
-    storage stable_token_2_reserved: u128;  // Amount reserved for unredeemed vouchers (not available for swaps)
-    storage lp_token_reserved: u128;   // Amount reserved for unredeemed vouchers (not available for swaps)
+    storage stable_token_1_reserved: u128; // Amount reserved for unredeemed vouchers (not available for swaps)
+    storage stable_token_2_reserved: u128; // Amount reserved for unredeemed vouchers (not available for swaps)
+    storage lp_token_reserved: u128; // Amount reserved for unredeemed vouchers (not available for swaps)
 
-    async transition initialize() -> Future {
-        return finalize_initialize(self.caller);
-    }
-    async function finalize_initialize(caller: address) {
-        assert_eq(ADMIN_ADDRESS, caller);
-        
-        let is_already_initialized: bool = initialized.get_or_use(INITIALIZED_INDEX, false);
-        assert_eq(is_already_initialized, false);
-        
-        initialized.set(INITIALIZED_INDEX, true);
+    fn initialize() -> Final {
+        let caller: address = self.caller;
+        return final {
+            assert_eq(ADMIN_ADDRESS, caller);
 
-        stable_token_1_balance = 0u128;
-        stable_token_2_balance = 0u128;
-        stable_token_1_reserved = 0u128;
-        stable_token_2_reserved = 0u128;
-        lp_token_reserved = 0u128;
+            let is_already_initialized: bool = initialized.get_or_use(INITIALIZED_INDEX, false);
+            assert_eq(is_already_initialized, false);
 
-        /*
-        initialize the lp token?
-        */
+            initialized.set(INITIALIZED_INDEX, true);
+
+            stable_token_1_balance = 0u128;
+            stable_token_2_balance = 0u128;
+            stable_token_1_reserved = 0u128;
+            stable_token_2_reserved = 0u128;
+            lp_token_reserved = 0u128;
+        };
     }
 
-    async transition add_liquidity(
+    fn add_liquidity(
         stable_token_1_amount: u128,
         stable_token_2_amount: u128,
-        stable_token_1_record: stable_token_1.aleo/Token,
-        stable_token_2_record: stable_token_2.aleo/Token,
+        stable_token_1_record: stable_token_1.aleo::Token,
+        stable_token_2_record: stable_token_2.aleo::Token,
         min_mint_amount: u128,
-        stable_token_1_merkle_proof: [stable_token_1.aleo/MerkleProof; 2],
-        stable_token_2_merkle_proof: [stable_token_2.aleo/MerkleProof; 2], 
+        stable_token_1_merkle_proof: [stable_token_1.aleo::MerkleProof; 2],
+        stable_token_2_merkle_proof: [stable_token_2.aleo::MerkleProof; 2],
         voucher_id: field,
-    ) -> (stable_token_1.aleo/Token, stable_token_2.aleo/Token, lp_token.aleo/Token, LP_Voucher, Future) {
-        let transfer_stable_token_1: (stable_token_1.aleo/ComplianceRecord, stable_token_1.aleo/Token, Future) = stable_token_1.aleo/transfer_private_to_public(
+    ) -> (
+        stable_token_1.aleo::Token, stable_token_2.aleo::Token, lp_token.aleo::Token, LP_Voucher,
+        Final,
+    ) {
+        let transfer_stable_token_1: (
+            stable_token_1.aleo::ComplianceRecord, stable_token_1.aleo::Token, Final,
+        ) = stable_token_1.aleo::transfer_private_to_public(
             self.address,
             stable_token_1_amount,
             stable_token_1_record,
-            stable_token_1_merkle_proof
+            stable_token_1_merkle_proof,
         );
-        let transfer_stable_token_2: (stable_token_2.aleo/ComplianceRecord, stable_token_2.aleo/Token, Future) = stable_token_2.aleo/transfer_private_to_public(
+        let transfer_stable_token_2: (
+            stable_token_2.aleo::ComplianceRecord, stable_token_2.aleo::Token, Final,
+        ) = stable_token_2.aleo::transfer_private_to_public(
             self.address,
             stable_token_2_amount,
             stable_token_2_record,
-            stable_token_2_merkle_proof
+            stable_token_2_merkle_proof,
         );
-
-        let mint_lp_token: (lp_token.aleo/ComplianceRecord, lp_token.aleo/Token, Future) = lp_token.aleo/mint_private(self.signer, min_mint_amount);
-        
-        let lp_voucher_record = LP_Voucher {
-            owner: self.signer,
-            voucher_id: voucher_id
-        };
-
+        let mint_lp_token: (lp_token.aleo::ComplianceRecord, lp_token.aleo::Token, Final) = lp_token.aleo::mint_private(
+            self.signer,
+            min_mint_amount,
+        );
+        let lp_voucher_record = LP_Voucher { owner: self.signer, voucher_id: voucher_id };
         return (
             transfer_stable_token_1.1,
             transfer_stable_token_2.1,
             mint_lp_token.1,
             lp_voucher_record,
-            finalize_add_liquidity(
-                stable_token_1_amount,
-                stable_token_2_amount,
-                voucher_id,
-                min_mint_amount,
-                transfer_stable_token_1.2,
-                transfer_stable_token_2.2,
-                mint_lp_token.2,
-            )
+            final {
+                // the total lp token should include the vouchers
+                let token_info = lp_token.aleo::token_info.get(true);
+                let token_supply = token_info.supply + lp_token_reserved.unwrap();
+                let balances_before: [u128; 2] = [
+                    stable_token_1_balance.unwrap(),
+                    stable_token_2_balance.unwrap(),
+                ];
+                let invariant_before: u128 = token_supply > 0 ? compute_invariant(balances_before) : 0u128;
+                let balances_after_deposit: [u128; 2] = [
+                    balances_before[0] + stable_token_1_amount,
+                    balances_before[1] + stable_token_2_amount,
+                ];
+                //Invariant after change
+                let invariant_after_deposit: u128 = compute_invariant(balances_after_deposit);
+                assert(invariant_after_deposit > invariant_before);
+
+                // # Calculate, how much lp tokens to mint
+                let voucher_exists = vouchers.contains(voucher_id);
+                assert_eq(voucher_exists, false);
+                if (token_supply == 0) {
+                    assert_neq(stable_token_1_amount, 0u128);
+                    assert_neq(stable_token_2_amount, 0u128);
+                    stable_token_1_balance = balances_after_deposit[0];
+                    stable_token_2_balance = balances_after_deposit[1];
+                    let mint_amount: u128 = invariant_after_deposit;
+                    // Validate the full LP mint amount against max_supply
+                    assert(token_supply + mint_amount < token_info.max_supply);
+
+                    let voucher_amount = mint_amount - min_mint_amount;
+                    vouchers.set(voucher_id, voucher_amount);
+                    lp_token_reserved = lp_token_reserved.unwrap() + voucher_amount;
+                } else {
+                    // We need to recalculate the invariant accounting for fees
+                    // to calculate fair user's share
+                    // Only account for fees if we are not the first to deposit
+                    let fee_per_token: u128 = FEE / 2;
+                    let ideal_balance: u128 = invariant_after_deposit
+                        * balances_before[0]
+                        / invariant_before;
+                    let difference: u128 = absolute_difference(
+                        ideal_balance,
+                        balances_after_deposit[0],
+                    );
+                    let stable_token_1_fee: u128 = fee_per_token * difference / FEE_DENOMINATOR;
+                    stable_token_1_balance = balances_after_deposit[0]
+                        - stable_token_1_fee * ADMIN_FEE / FEE_DENOMINATOR;
+                    ideal_balance = invariant_after_deposit * balances_before[1] / invariant_before;
+                    difference = absolute_difference(ideal_balance, balances_after_deposit[1]);
+                    let stable_token_2_fee: u128 = fee_per_token * difference / FEE_DENOMINATOR;
+                    stable_token_2_balance = balances_after_deposit[1]
+                        - stable_token_2_fee * ADMIN_FEE / FEE_DENOMINATOR;
+                    let balances_after_fee: [u128; 2] = [
+                        balances_after_deposit[0] - stable_token_1_fee,
+                        balances_after_deposit[1] - stable_token_2_fee,
+                    ];
+                    let invariant_after_fee: u128 = compute_invariant(balances_after_fee);
+                    let mint_amount: u128 = token_supply
+                        * (invariant_after_fee - invariant_before)
+                        / invariant_before;
+
+                    // Validate the full LP mint amount against max_supply
+                    assert(token_supply + mint_amount < token_info.max_supply);
+
+                    let voucher_amount = mint_amount - min_mint_amount;
+                    vouchers.set(voucher_id, voucher_amount);
+
+                    lp_token_reserved = lp_token_reserved.unwrap() + voucher_amount;
+                }
+                transfer_stable_token_1.2.run();
+                transfer_stable_token_2.2.run();
+                mint_lp_token.2.run();
+            },
         );
     }
-    async function finalize_add_liquidity(
-        stable_token_1_amount: u128,
-        stable_token_2_amount: u128,
-        voucher_id: field,
-        min_mint_amount: u128,
-        transfer_stable_token_1: Future,
-        transfer_stable_token_2: Future,
-        mint_lp_token: Future
-    ) {
-        // the total lp token should include the vouchers
-        let token_info = lp_token.aleo/token_info.get(true);
-        let token_supply =  token_info.supply + lp_token_reserved.unwrap();
 
-        let balances_before: [u128; 2] = [stable_token_1_balance.unwrap(), stable_token_2_balance.unwrap()];
-        let invariant_before: u128 = token_supply > 0 ? compute_invariant(balances_before) : 0u128;
-
-        let balances_after_deposit: [u128; 2] = [balances_before[0] + stable_token_1_amount, balances_before[1] + stable_token_2_amount];
-
-        //Invariant after change
-        let invariant_after_deposit: u128 = compute_invariant(balances_after_deposit);
-        assert(invariant_after_deposit > invariant_before);
-
-        // # Calculate, how much lp tokens to mint
-
-        let voucher_exists = vouchers.contains(voucher_id);
-        assert_eq(voucher_exists, false);
-
-        if (token_supply == 0) {
-            assert_neq(stable_token_1_amount, 0u128);
-            assert_neq(stable_token_2_amount, 0u128);
-            stable_token_1_balance = balances_after_deposit[0];
-            stable_token_2_balance = balances_after_deposit[1];
-            let mint_amount: u128 =  invariant_after_deposit;
-
-            // Validate the full LP mint amount against max_supply
-            assert(token_supply + mint_amount < token_info.max_supply);
-
-            let voucher_amount = mint_amount - min_mint_amount;
-            vouchers.set(voucher_id, voucher_amount);
-            lp_token_reserved = lp_token_reserved.unwrap() + voucher_amount;
-        } else {
-            // We need to recalculate the invariant accounting for fees
-            // to calculate fair user's share
-            // Only account for fees if we are not the first to deposit
-            let fee_per_token: u128 = FEE / 2;
-            let ideal_balance: u128 = invariant_after_deposit * balances_before[0] / invariant_before;
-            let difference: u128 = absolute_difference(ideal_balance, balances_after_deposit[0]);
-            let stable_token_1_fee: u128 = fee_per_token * difference / FEE_DENOMINATOR;
-            stable_token_1_balance = balances_after_deposit[0] - stable_token_1_fee * ADMIN_FEE / FEE_DENOMINATOR;
-            ideal_balance = invariant_after_deposit * balances_before[1] / invariant_before;
-            difference = absolute_difference(ideal_balance, balances_after_deposit[1]);
-            let stable_token_2_fee: u128 = fee_per_token * difference / FEE_DENOMINATOR;
-            stable_token_2_balance = balances_after_deposit[1] - stable_token_2_fee * ADMIN_FEE / FEE_DENOMINATOR;
-            let balances_after_fee: [u128; 2] = [balances_after_deposit[0] - stable_token_1_fee, balances_after_deposit[1] - stable_token_2_fee];
-            let invariant_after_fee: u128 = compute_invariant(balances_after_fee);
-            let mint_amount: u128 = token_supply * (invariant_after_fee - invariant_before) / invariant_before;
-
-            // Validate the full LP mint amount against max_supply
-            assert(token_supply + mint_amount < token_info.max_supply);
-
-            let voucher_amount = mint_amount - min_mint_amount;
-            vouchers.set(voucher_id, voucher_amount);
-
-            lp_token_reserved = lp_token_reserved.unwrap() + voucher_amount;
-        }
-
-        transfer_stable_token_1.await();
-        transfer_stable_token_2.await();
-        mint_lp_token.await();
-    }
-
-    async transition remove_liquidity(
-        lp_token_amount: u128, 
-        min_stable_token_1_amount: u128, 
+    fn remove_liquidity(
+        lp_token_amount: u128,
+        min_stable_token_1_amount: u128,
         min_stable_token_2_amount: u128,
-        lp_token_record: lp_token.aleo/Token,
+        lp_token_record: lp_token.aleo::Token,
         stable_token_1_voucher_id: field,
         stable_token_2_voucher_id: field,
-    ) -> (lp_token.aleo/Token, stable_token_1.aleo/Token, stable_token_2.aleo/Token, Stable_Token_1_Voucher, Stable_Token_2_Voucher, Future) {
-        let burn_lp_token: (lp_token.aleo/ComplianceRecord, lp_token.aleo/Token, Future) = lp_token.aleo/burn_private(lp_token_record, lp_token_amount);
-        let transfer_stable_token_1: (stable_token_1.aleo/ComplianceRecord, stable_token_1.aleo/Token, Future) = stable_token_1.aleo/transfer_public_to_private(lp_token_record.owner, min_stable_token_1_amount);
-        let transfer_stable_token_2: (stable_token_2.aleo/ComplianceRecord, stable_token_2.aleo/Token, Future) = stable_token_2.aleo/transfer_public_to_private(lp_token_record.owner, min_stable_token_2_amount);    
-
+    ) -> (
+        lp_token.aleo::Token, stable_token_1.aleo::Token, stable_token_2.aleo::Token,
+        Stable_Token_1_Voucher, Stable_Token_2_Voucher, Final,
+    ) {
+        let burn_lp_token: (lp_token.aleo::ComplianceRecord, lp_token.aleo::Token, Final) = lp_token.aleo::burn_private(
+            lp_token_record,
+            lp_token_amount,
+        );
+        let transfer_stable_token_1: (
+            stable_token_1.aleo::ComplianceRecord, stable_token_1.aleo::Token, Final,
+        ) = stable_token_1.aleo::transfer_public_to_private(
+            lp_token_record.owner,
+            min_stable_token_1_amount,
+        );
+        let transfer_stable_token_2: (
+            stable_token_2.aleo::ComplianceRecord, stable_token_2.aleo::Token, Final,
+        ) = stable_token_2.aleo::transfer_public_to_private(
+            lp_token_record.owner,
+            min_stable_token_2_amount,
+        );
         let stable_coin_1_voucher = Stable_Token_1_Voucher {
             owner: lp_token_record.owner,
-            voucher_id: stable_token_1_voucher_id
+            voucher_id: stable_token_1_voucher_id,
         };
-
         let stable_coin_2_voucher = Stable_Token_2_Voucher {
             owner: lp_token_record.owner,
-            voucher_id: stable_token_2_voucher_id
+            voucher_id: stable_token_2_voucher_id,
         };
         return (
-            burn_lp_token.1,
-            transfer_stable_token_1.1,
-            transfer_stable_token_2.1,
-            stable_coin_1_voucher,
-            stable_coin_2_voucher,
-            finalize_remove_liquidity(
-                lp_token_amount,
-                min_stable_token_1_amount,
-                min_stable_token_2_amount,
-                stable_token_1_voucher_id,
-                stable_token_2_voucher_id,
-                burn_lp_token.2,
-                transfer_stable_token_1.2,
-                transfer_stable_token_2.2
-            )
+            burn_lp_token.1, transfer_stable_token_1.1, transfer_stable_token_2.1,
+            stable_coin_1_voucher, stable_coin_2_voucher,
+            final {
+                let token_info = lp_token.aleo::token_info.get(true);
+                let token_supply = token_info.supply + lp_token_reserved.unwrap();
+                let amount_token_1: u128 = stable_token_1_balance.unwrap()
+                    * lp_token_amount
+                    / token_supply;
+                stable_token_1_balance = stable_token_1_balance.unwrap() - amount_token_1;
+                let voucher_1_exists = vouchers.contains(stable_token_1_voucher_id);
+                assert_eq(voucher_1_exists, false);
+                let stable_token_1_voucher_amount = amount_token_1 - min_stable_token_1_amount;
+                vouchers.set(stable_token_1_voucher_id, stable_token_1_voucher_amount);
+                stable_token_1_reserved = stable_token_1_reserved.unwrap()
+                    + stable_token_1_voucher_amount;
+
+                let amount_token_2: u128 = stable_token_2_balance.unwrap()
+                    * lp_token_amount
+                    / token_supply;
+                stable_token_2_balance = stable_token_2_balance.unwrap() - amount_token_2;
+                let voucher_2_exists = vouchers.contains(stable_token_2_voucher_id);
+                assert_eq(voucher_2_exists, false);
+                let stable_token_2_voucher_amount = amount_token_2 - min_stable_token_2_amount;
+                vouchers.set(stable_token_2_voucher_id, stable_token_2_voucher_amount);
+                stable_token_2_reserved = stable_token_2_reserved.unwrap()
+                    + stable_token_2_voucher_amount;
+
+                burn_lp_token.2.run();
+                transfer_stable_token_1.2.run();
+                transfer_stable_token_2.2.run();
+            },
         );
     }
 
-    async function finalize_remove_liquidity(
-        lp_token_amount: u128, 
-        min_stable_token_1_amount: u128, 
-        min_stable_token_2_amount: u128,
-        stable_token_1_voucher_id: field,
-        stable_token_2_voucher_id: field,
-        burn_lp_token: Future,
-        transfer_stable_token_1: Future,
-        transfer_stable_token_2: Future,
-    ) {
-        let token_info = lp_token.aleo/token_info.get(true);
-        let token_supply =  token_info.supply + lp_token_reserved.unwrap();
-
-        let amount_token_1: u128 = stable_token_1_balance.unwrap() * lp_token_amount / token_supply;
-        stable_token_1_balance = stable_token_1_balance.unwrap() - amount_token_1;
-        let voucher_1_exists = vouchers.contains(stable_token_1_voucher_id);
-        assert_eq(voucher_1_exists, false);
-        let stable_token_1_voucher_amount = amount_token_1 - min_stable_token_1_amount;
-        vouchers.set(stable_token_1_voucher_id, stable_token_1_voucher_amount);
-        stable_token_1_reserved = stable_token_1_reserved.unwrap() + stable_token_1_voucher_amount;
-
-        let amount_token_2: u128 = stable_token_2_balance.unwrap() * lp_token_amount / token_supply;
-        stable_token_2_balance = stable_token_2_balance.unwrap() - amount_token_2;
-        let voucher_2_exists = vouchers.contains(stable_token_2_voucher_id);
-        assert_eq(voucher_2_exists, false);
-        let stable_token_2_voucher_amount = amount_token_2 - min_stable_token_2_amount;
-        vouchers.set(stable_token_2_voucher_id, stable_token_2_voucher_amount);
-        stable_token_2_reserved = stable_token_2_reserved.unwrap() + stable_token_2_voucher_amount;
-
-        burn_lp_token.await();
-        transfer_stable_token_1.await();
-        transfer_stable_token_2.await();
-    }
-
-    async transition exchange_1_for_2(
+    fn exchange_1_for_2(
         input_amount: u128,
         min_output_amount: u128,
-        input_record: stable_token_1.aleo/Token,
-        merkle_proof: [stable_token_1.aleo/MerkleProof;2],
-        voucher_id: field
-    ) -> (stable_token_1.aleo/Token, stable_token_2.aleo/Token, Stable_Token_2_Voucher, Future) {
-        let transfer_input_token: (stable_token_1.aleo/ComplianceRecord, stable_token_1.aleo/Token, Future) = stable_token_1.aleo/transfer_private_to_public(
+        input_record: stable_token_1.aleo::Token,
+        merkle_proof: [stable_token_1.aleo::MerkleProof; 2],
+        voucher_id: field,
+    ) -> (stable_token_1.aleo::Token, stable_token_2.aleo::Token, Stable_Token_2_Voucher, Final) {
+        let transfer_input_token: (
+            stable_token_1.aleo::ComplianceRecord, stable_token_1.aleo::Token, Final,
+        ) = stable_token_1.aleo::transfer_private_to_public(
             self.address,
             input_amount,
             input_record,
-            merkle_proof
+            merkle_proof,
         );
-        let transfer_output_token: (stable_token_2.aleo/ComplianceRecord, stable_token_2.aleo/Token, Future) = stable_token_2.aleo/transfer_public_to_private(
-            input_record.owner,
-            min_output_amount,
-        );
-
-        let voucher = Stable_Token_2_Voucher {
-            owner: input_record.owner,
-            voucher_id: voucher_id
-        };
-
+        let transfer_output_token: (
+            stable_token_2.aleo::ComplianceRecord, stable_token_2.aleo::Token, Final,
+        ) = stable_token_2.aleo::transfer_public_to_private(input_record.owner, min_output_amount);
+        let voucher = Stable_Token_2_Voucher { owner: input_record.owner, voucher_id: voucher_id };
         return (
             transfer_input_token.1, // input token record leftover
             transfer_output_token.1, // output token record
             voucher,
-            finalize_exchange_1_for_2(input_amount, min_output_amount, voucher_id, transfer_input_token.2, transfer_output_token.2)
+            final {
+                let input_token_balance = stable_token_1_balance.unwrap();
+                let output_token_balance = stable_token_2_balance.unwrap();
+                let new_input_token_balance: u128 = input_token_balance + input_amount;
+                let new_output_token_balance: u128 = compute_output_token_balance(
+                    new_input_token_balance,
+                    input_token_balance,
+                    output_token_balance,
+                );
+                let gross_output_amount: u128 = output_token_balance - new_output_token_balance;
+
+                let fee_amount: u128 = gross_output_amount * FEE / FEE_DENOMINATOR;
+                let admin_fee_amount: u128 = fee_amount * ADMIN_FEE / FEE_DENOMINATOR;
+
+                stable_token_1_balance = new_input_token_balance;
+                stable_token_2_balance = new_output_token_balance + (fee_amount - admin_fee_amount);
+
+                let net_output_amount: u128 = gross_output_amount - fee_amount;
+
+                let voucher_exists = vouchers.contains(voucher_id);
+                assert_eq(voucher_exists, false);
+                let voucher_amount = net_output_amount - min_output_amount;
+                vouchers.set(voucher_id, voucher_amount);
+                stable_token_2_reserved = stable_token_2_reserved.unwrap() + voucher_amount;
+
+                transfer_input_token.2.run();
+                transfer_output_token.2.run();
+            },
         );
     }
 
-    async function finalize_exchange_1_for_2(
+    fn exchange_2_for_1(
         input_amount: u128,
         min_output_amount: u128,
+        input_record: stable_token_2.aleo::Token,
+        merkle_proof: [stable_token_2.aleo::MerkleProof; 2],
         voucher_id: field,
-        transfer_input_token: Future,
-        transfer_output_token: Future
-    ) {
-        let input_token_balance = stable_token_1_balance.unwrap();
-        let output_token_balance = stable_token_2_balance.unwrap();
-        let new_input_token_balance: u128 = input_token_balance + input_amount;
-        let new_output_token_balance: u128 = compute_output_token_balance(new_input_token_balance, input_token_balance, output_token_balance);
-        let gross_output_amount: u128 = output_token_balance - new_output_token_balance;
-
-        let fee_amount: u128 = gross_output_amount * FEE / FEE_DENOMINATOR;
-        let admin_fee_amount: u128 = fee_amount * ADMIN_FEE / FEE_DENOMINATOR;
-
-        stable_token_1_balance = new_input_token_balance;
-        stable_token_2_balance = new_output_token_balance + (fee_amount - admin_fee_amount);
-
-        let net_output_amount: u128 = gross_output_amount - fee_amount;
-
-        let voucher_exists = vouchers.contains(voucher_id);
-        assert_eq(voucher_exists, false);
-        let voucher_amount = net_output_amount - min_output_amount;
-        vouchers.set(voucher_id, voucher_amount);
-        stable_token_2_reserved = stable_token_2_reserved.unwrap() + voucher_amount;
-
-        transfer_input_token.await();
-        transfer_output_token.await();
-    }
-
-    async transition exchange_2_for_1(
-        input_amount: u128,
-        min_output_amount: u128,
-        input_record: stable_token_2.aleo/Token,
-        merkle_proof: [stable_token_2.aleo/MerkleProof;2],
-        voucher_id: field
-    ) -> (stable_token_2.aleo/Token, stable_token_1.aleo/Token, Stable_Token_1_Voucher, Future) {
-        let transfer_input_token: (stable_token_2.aleo/ComplianceRecord, stable_token_2.aleo/Token, Future) = stable_token_2.aleo/transfer_private_to_public(
+    ) -> (stable_token_2.aleo::Token, stable_token_1.aleo::Token, Stable_Token_1_Voucher, Final) {
+        let transfer_input_token: (
+            stable_token_2.aleo::ComplianceRecord, stable_token_2.aleo::Token, Final,
+        ) = stable_token_2.aleo::transfer_private_to_public(
             self.address,
             input_amount,
             input_record,
-            merkle_proof
+            merkle_proof,
         );
-        let transfer_output_token: (stable_token_1.aleo/ComplianceRecord, stable_token_1.aleo/Token, Future) = stable_token_1.aleo/transfer_public_to_private(
-            input_record.owner,
-            min_output_amount,
-        );
-
-        let voucher = Stable_Token_1_Voucher {
-            owner: input_record.owner,
-            voucher_id: voucher_id
-        };
-
+        let transfer_output_token: (
+            stable_token_1.aleo::ComplianceRecord, stable_token_1.aleo::Token, Final,
+        ) = stable_token_1.aleo::transfer_public_to_private(input_record.owner, min_output_amount);
+        let voucher = Stable_Token_1_Voucher { owner: input_record.owner, voucher_id: voucher_id };
         return (
             transfer_input_token.1, // input token record leftover
             transfer_output_token.1, // output token record
             voucher,
-            finalize_exchange_2_for_1(input_amount, min_output_amount, voucher_id, transfer_input_token.2, transfer_output_token.2)
+            final {
+                let input_token_balance = stable_token_2_balance.unwrap();
+                let output_token_balance = stable_token_1_balance.unwrap();
+                let new_input_token_balance: u128 = input_token_balance + input_amount;
+                let new_output_token_balance: u128 = compute_output_token_balance(
+                    new_input_token_balance,
+                    input_token_balance,
+                    output_token_balance,
+                );
+                let gross_output_amount: u128 = output_token_balance - new_output_token_balance;
+
+                let fee_amount: u128 = gross_output_amount * FEE / FEE_DENOMINATOR;
+                let admin_fee_amount: u128 = fee_amount * ADMIN_FEE / FEE_DENOMINATOR;
+
+                stable_token_2_balance = new_input_token_balance;
+                stable_token_1_balance = new_output_token_balance + (fee_amount - admin_fee_amount);
+
+                let net_output_amount: u128 = gross_output_amount - fee_amount;
+
+                let voucher_exists = vouchers.contains(voucher_id);
+                assert_eq(voucher_exists, false);
+                let voucher_amount = net_output_amount - min_output_amount;
+                vouchers.set(voucher_id, voucher_amount);
+                stable_token_1_reserved = stable_token_1_reserved.unwrap() + voucher_amount;
+
+                transfer_input_token.2.run();
+                transfer_output_token.2.run();
+            },
         );
     }
 
-    async function finalize_exchange_2_for_1(
-        input_amount: u128,
-        min_output_amount: u128,
-        voucher_id: field,
-        transfer_input_token: Future,
-        transfer_output_token: Future
-    ) {
-        let input_token_balance = stable_token_2_balance.unwrap();
-        let output_token_balance = stable_token_1_balance.unwrap();
-        let new_input_token_balance: u128 = input_token_balance + input_amount;
-        let new_output_token_balance: u128 = compute_output_token_balance(new_input_token_balance, input_token_balance, output_token_balance);
-        let gross_output_amount: u128 = output_token_balance - new_output_token_balance;
-
-        let fee_amount: u128 = gross_output_amount * FEE / FEE_DENOMINATOR;
-        let admin_fee_amount: u128 = fee_amount * ADMIN_FEE / FEE_DENOMINATOR;
-
-        stable_token_2_balance = new_input_token_balance;
-        stable_token_1_balance = new_output_token_balance + (fee_amount - admin_fee_amount);
-
-        let net_output_amount: u128 = gross_output_amount - fee_amount;
-
-        let voucher_exists = vouchers.contains(voucher_id);
-        assert_eq(voucher_exists, false);
-        let voucher_amount = net_output_amount - min_output_amount;
-        vouchers.set(voucher_id, voucher_amount);
-        stable_token_1_reserved = stable_token_1_reserved.unwrap() + voucher_amount;
-
-        transfer_input_token.await();
-        transfer_output_token.await();
-    }
-
-    /// @dev Calculate invariant D for balances xp with amplification A, for n=2.
-    /// This matches the standard Curve StableSwap Newton iteration.
-    inline compute_invariant(token_balances: [u128;2]) -> u128 {
-        let total_balance: u128 = token_balances[0] + token_balances[1];
-        if(total_balance == 0u128) {
-            return 0u128;
-        }
-        let invariant: u128 = total_balance;
-        for i: u8 in 0u8..MAX_ITERATIONS {
-            let product_term: u128 = invariant * invariant / (token_balances[0] * 2 + 1);  // +1 is to prevent /0
-            product_term = product_term * invariant / (token_balances[1] * 2 + 1);  // +1 is to prevent /0
-            let previous_invariant: u128 = invariant;
-            invariant = (ANN * total_balance + product_term * 2) * invariant / ((ANN - 1) * invariant + 3 * product_term + 1);
-            if (absolute_difference(invariant, previous_invariant) <= 1) {
-                return invariant;
-            }
-        }
-        return invariant;
-    }
-
-    /// @dev Calculate for output pool balance y given the input reserve x and invariant D,
-    /// This matches the standard Curve StableSwap Newton iteration.
-    inline compute_output_token_balance(new_input_token_balance: u128, input_token_balance: u128, output_token_balance: u128) -> u128 {
-        let token_balances: [u128;2] = [input_token_balance, output_token_balance];
-
-        let invariant = compute_invariant(token_balances);
-        let product_term: u128 = invariant;
-        product_term = product_term * invariant / (new_input_token_balance * 2);
-        product_term = product_term * invariant / (ANN * 2);
-
-        let sum_term: u128 = new_input_token_balance + invariant / ANN;
-
-        let new_output_token_balance: u128 = invariant;
-        for k in 0u8..MAX_ITERATIONS {
-            let previous_estimate: u128 = new_output_token_balance;
-            new_output_token_balance = (new_output_token_balance*new_output_token_balance + product_term) / (2 * new_output_token_balance + sum_term - invariant);
-            if(absolute_difference(new_output_token_balance, previous_estimate) <= 1) {
-                return new_output_token_balance;
-            }
-        }
-        
-
-        return new_output_token_balance;
-    }
-
-    async transition redeem_stable_token_1_voucher(voucher: Stable_Token_1_Voucher, amount: u128) -> (stable_token_1.aleo/Token, Stable_Token_1_Voucher, Future) {
-        let transfer_call: (stable_token_1.aleo/ComplianceRecord, stable_token_1.aleo/Token, Future) = stable_token_1.aleo/transfer_public_to_private(voucher.owner, amount);
-        
+    fn redeem_stable_token_1_voucher(
+        voucher: Stable_Token_1_Voucher,
+        amount: u128,
+    ) -> (stable_token_1.aleo::Token, Stable_Token_1_Voucher, Final) {
+        let transfer_call: (
+            stable_token_1.aleo::ComplianceRecord, stable_token_1.aleo::Token, Final,
+        ) = stable_token_1.aleo::transfer_public_to_private(voucher.owner, amount);
         let new_voucher = Stable_Token_1_Voucher {
             owner: voucher.owner,
-            voucher_id: voucher.voucher_id
+            voucher_id: voucher.voucher_id,
         };
+        let voucher_id = voucher.voucher_id;
+        return (
+            transfer_call.1, new_voucher,
+            final {
+                let voucher_amount = vouchers.get(voucher_id);
+                vouchers.set(voucher_id, voucher_amount - amount);
+                stable_token_1_reserved = stable_token_1_reserved.unwrap() - amount;
 
-        return (transfer_call.1, new_voucher, f_redeem_stable_token_1_voucher(voucher.voucher_id, amount, transfer_call.2));
+                transfer_call.2.run();
+            },
+        );
     }
-    async function f_redeem_stable_token_1_voucher(voucher_id: field, amount: u128, transfer_call: Future) {
-        let voucher_amount = vouchers.get(voucher_id);
-        vouchers.set(voucher_id, voucher_amount - amount);
-        stable_token_1_reserved = stable_token_1_reserved.unwrap() - amount;
 
-        transfer_call.await();
-    }
-    
-    async transition redeem_stable_token_2_voucher(voucher: Stable_Token_2_Voucher, amount: u128) -> (stable_token_2.aleo/Token, Stable_Token_2_Voucher, Future) {
-        let transfer_call: (stable_token_2.aleo/ComplianceRecord, stable_token_2.aleo/Token, Future) = stable_token_2.aleo/transfer_public_to_private(voucher.owner, amount);
-        
+    fn redeem_stable_token_2_voucher(
+        voucher: Stable_Token_2_Voucher,
+        amount: u128,
+    ) -> (stable_token_2.aleo::Token, Stable_Token_2_Voucher, Final) {
+        let transfer_call: (
+            stable_token_2.aleo::ComplianceRecord, stable_token_2.aleo::Token, Final,
+        ) = stable_token_2.aleo::transfer_public_to_private(voucher.owner, amount);
         let new_voucher = Stable_Token_2_Voucher {
             owner: voucher.owner,
-            voucher_id: voucher.voucher_id
+            voucher_id: voucher.voucher_id,
         };
+        let voucher_id = voucher.voucher_id;
+        return (
+            transfer_call.1, new_voucher,
+            final {
+                let voucher_amount = vouchers.get(voucher_id);
+                vouchers.set(voucher_id, voucher_amount - amount);
+                stable_token_2_reserved = stable_token_2_reserved.unwrap() - amount;
 
-        return (transfer_call.1, new_voucher, f_redeem_stable_token_2_voucher(voucher.voucher_id, amount, transfer_call.2));
+                transfer_call.2.run();
+            },
+        );
     }
-    async function f_redeem_stable_token_2_voucher(voucher_id: field, amount: u128, transfer_call: Future) {
-        let voucher_amount = vouchers.get(voucher_id);
-        vouchers.set(voucher_id, voucher_amount - amount);
-        stable_token_2_reserved = stable_token_2_reserved.unwrap() - amount;
 
-        transfer_call.await();
+    fn redeem_lp_token_voucher(
+        voucher: LP_Voucher,
+        amount: u128,
+    ) -> (lp_token.aleo::Token, LP_Voucher, Final) {
+        let mint_call: (lp_token.aleo::ComplianceRecord, lp_token.aleo::Token, Final) = lp_token.aleo::mint_private(
+            voucher.owner,
+            amount,
+        );
+        let new_voucher = LP_Voucher { owner: voucher.owner, voucher_id: voucher.voucher_id };
+        let voucher_id = voucher.voucher_id;
+        return (
+            mint_call.1, new_voucher,
+            final {
+                let voucher_amount = vouchers.get(voucher_id);
+                vouchers.set(voucher_id, voucher_amount - amount);
+                lp_token_reserved = lp_token_reserved.unwrap() - amount;
+
+                mint_call.2.run();
+            },
+        );
     }
-    
-    async transition redeem_lp_token_voucher(voucher: LP_Voucher, amount: u128) -> (lp_token.aleo/Token, LP_Voucher, Future) {
-        let mint_call: (lp_token.aleo/ComplianceRecord, lp_token.aleo/Token, Future) = lp_token.aleo/mint_private(voucher.owner, amount);
-        
-        let new_voucher = LP_Voucher {
-            owner: voucher.owner,
-            voucher_id: voucher.voucher_id
+
+    fn withdraw_admin_fees(stable_token_1_amount: u128, stable_token_2_amount: u128) -> Final {
+        let transfer_stable_token_1: Final = stable_token_1.aleo::transfer_public(
+            ADMIN_ADDRESS,
+            stable_token_1_amount,
+        );
+        let transfer_stable_token_2: Final = stable_token_2.aleo::transfer_public(
+            ADMIN_ADDRESS,
+            stable_token_2_amount,
+        );
+        let caller: address = self.caller;
+        return final {
+            assert_eq(ADMIN_ADDRESS, caller);
+            let stable_token_1_pool_balance = stable_token_1.aleo::balances.get(self.address);
+            assert(stable_token_1_pool_balance
+                - (stable_token_1_balance.unwrap() + stable_token_1_reserved.unwrap())
+                >= stable_token_1_amount);
+            let stable_token_2_pool_balance = stable_token_2.aleo::balances.get(self.address);
+            assert(stable_token_2_pool_balance
+                - (stable_token_2_balance.unwrap() + stable_token_2_reserved.unwrap())
+                >= stable_token_2_amount);
+            transfer_stable_token_1.run();
+            transfer_stable_token_2.run();
         };
-
-        return (mint_call.1, new_voucher, f_redeem_lp_token_voucher(voucher.voucher_id, amount, mint_call.2));
-
-    }
-    async function f_redeem_lp_token_voucher(voucher_id: field, amount: u128, mint_call: Future) {
-        let voucher_amount = vouchers.get(voucher_id);
-        vouchers.set(voucher_id, voucher_amount - amount);
-        lp_token_reserved = lp_token_reserved.unwrap() - amount;
-
-        mint_call.await();
-    }
-
-    async transition withdraw_admin_fees(stable_token_1_amount: u128, stable_token_2_amount: u128) -> Future {
-        let transfer_stable_token_1: Future = stable_token_1.aleo/transfer_public(ADMIN_ADDRESS, stable_token_1_amount);
-        let transfer_stable_token_2: Future = stable_token_2.aleo/transfer_public(ADMIN_ADDRESS, stable_token_2_amount);
-
-        return finalize_withdraw_admin_fees(self.caller, stable_token_1_amount, stable_token_2_amount, transfer_stable_token_1, transfer_stable_token_2);
-    }
-    async function finalize_withdraw_admin_fees(caller: address, stable_token_1_amount: u128, stable_token_2_amount: u128, transfer_stable_token_1: Future, transfer_stable_token_2: Future) {
-        assert_eq(ADMIN_ADDRESS, caller);
-        let stable_token_1_pool_balance = stable_token_1.aleo/balances.get(self.address);
-        assert(stable_token_1_pool_balance - (stable_token_1_balance.unwrap() + stable_token_1_reserved.unwrap()) >= stable_token_1_amount);        
-        let stable_token_2_pool_balance = stable_token_2.aleo/balances.get(self.address);
-        assert(stable_token_2_pool_balance - (stable_token_2_balance.unwrap() + stable_token_2_reserved.unwrap()) >= stable_token_2_amount);
-
-        transfer_stable_token_1.await();
-        transfer_stable_token_2.await();
-    }
-
-    inline absolute_difference(a: u128, b: u128) -> u128 {
-      let diff: i128 = a as i128 - b as i128;
-      let abs_diff: i128 = diff;
-
-      if abs_diff < 0i128 {
-          abs_diff = 0i128 - abs_diff;
-      }
-
-      return abs_diff as u128;
     }
 }

--- a/programs/amm/lp_token.leo
+++ b/programs/amm/lp_token.leo
@@ -1,0 +1,889 @@
+import sealance_freezelist_registry.aleo;
+import multisig_core.aleo;
+
+program lp_token.aleo {
+    @custom
+    async constructor() {
+        // Only require multisig for upgrades - initial deployment has no checks.
+        if self.edition > 0u16 {
+            let signing_op_id = BHP256::hash_to_field(ChecksumEdition { checksum: self.checksum, edition: self.edition });
+
+            let wallet_signing_op_id_hash = BHP256::hash_to_field(multisig_core.aleo/WalletSigningOpId { wallet_id: self.address, signing_op_id: signing_op_id });
+            let signing_complete = multisig_core.aleo/completed_signing_ops.contains(wallet_signing_op_id_hash);
+            assert(signing_complete);
+        }
+    }
+
+    // A helper for calculating a signing_op_id from the program's checksum and edition.
+    // By deriving the signing_op_id from both we ensure that downgrades cannot take place.
+    transition get_signing_op_id_for_deploy(checksum: [u8; 32], edition: u16) -> field {
+        return BHP256::hash_to_field(ChecksumEdition { checksum: checksum, edition: edition });
+    }
+
+    record Token {
+        owner: address,
+        amount: u128
+    }
+
+    // Compliance record used for the investigator
+    record ComplianceRecord {
+        owner: address,
+        amount: u128,
+        sender: address,
+        recipient: address
+    }
+
+    record Credentials {
+        owner: address,
+        freeze_list_root: field,
+    }
+
+    struct MerkleProof {
+        siblings: [field; 16],
+        leaf_index: u32
+    }
+
+    struct ChecksumEdition {
+        checksum: [u8; 32],
+        edition: u16,
+    }
+
+    struct TokenInfo {
+        name: u128, // ASCII text represented in bits, and the u128 value of the bitstring
+        symbol: u128, // ASCII text represented in bits, and the u128 value of the bitstring
+        decimals: u8,
+        supply: u128,
+        max_supply: u128,
+    }
+
+    struct TokenAllowance {
+        account: address,
+        spender: address,
+    }
+    
+    const TOKEN_INFO_INDEX: bool = true;
+    // token specs
+    mapping token_info: bool => TokenInfo;
+
+    mapping balances: address => u128;
+    mapping allowances: field => u128; // hash(account, spender) => TokenAllowance
+
+    // Roles can be assigned using bitmasking to allow multiple roles per address
+    const NONE_ROLE: u16 = 0u16;
+    const MINTER_ROLE: u16 = 1u16;
+    const BURNER_ROLE: u16 = 2u16;
+    const PAUSE_ROLE: u16 = 4u16;   // can pause/unpause transfers
+    const MANAGER_ROLE: u16 = 8u16; // can only assign roles
+    mapping address_to_role: address => u16;
+
+    // Only this address can deploy and initialize the program
+    const DEPLOYER_ADDRESS: address = aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px;
+
+    // This address receives compliance records (can be updated with the contract upgrade)
+    const INVESTIGATOR_ADDRESS: address = aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px;
+
+    const PAUSE_STATUS_INDEX: bool = true;
+    mapping pause: bool => bool;
+
+    const ZERO_ADDRESS: address = aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc; // ZERO_ADDRESS as field equals to 0field
+    const CURRENT_FREEZE_LIST_ROOT_INDEX: u8 = 1u8;
+    const PREVIOUS_FREEZE_LIST_ROOT_INDEX: u8 = 2u8;
+    const BLOCK_HEIGHT_WINDOW_INDEX: bool = true;
+    const ROOT_UPDATED_HEIGHT_INDEX: bool = true;
+    // Maximum depth of the Merkle tree used in freeze list proofs.
+    // The siblings array has MAX_TREE_DEPTH + 1 elements because siblings[0] holds the leaf itself.
+    const MAX_TREE_DEPTH: u32 = 15u32;
+
+    // -------------------------
+    // Called by token admins
+    // -------------------------
+
+
+    // Updates the address assigned to a given role.
+    // Can only be called by the current role manager.
+    async transition update_role(public new_address: address, role: u16) -> Future {
+        return f_update_role(new_address, self.caller, role);
+    }
+    async function f_update_role(new_address: address, caller: address, new_role: u16) {
+        let current_role: u16 = address_to_role.get(caller);
+        assert(current_role & MANAGER_ROLE == MANAGER_ROLE);
+        
+        if (caller == new_address) { 
+            assert(new_role & MANAGER_ROLE == MANAGER_ROLE); 
+        }
+
+        address_to_role.set(new_address, new_role);
+
+    }
+
+    // Initializes the freeze list, token specifications, the admin and the investigator.
+    // Can be called only once and only by the INITIAL_ADMIN    
+    // Sets the token metadata (name, symbol, decimals, max supply).
+    // Sets the block height window, the initial empty Merkle root,
+    // and initialize the freeze_list_last_index, freeze_list, and freeze_list_index with a ZERO_ADDRESS placeholder.
+    async transition initialize(
+        public name: u128,
+        public symbol: u128,
+        public decimals: u8,
+        public max_supply: u128,
+        public admin: address,
+    ) -> Future {
+        return finalize_initialize(
+            name,
+            symbol,
+            decimals,
+            max_supply,
+            admin,
+            self.caller,
+        );
+    }
+    async function finalize_initialize(
+        name: u128,
+        symbol: u128,
+        decimals: u8,
+        max_supply: u128,
+        admin: address, 
+        caller: address,
+    ) {
+        // Check if the token has already been initialized
+        let already_initialized: bool = token_info.contains(TOKEN_INFO_INDEX);
+        assert_eq(already_initialized, false);
+        
+        // Only the INITIAL_CONFIGURATION_ADDRESS can initialize the contract
+        assert_eq(caller, DEPLOYER_ADDRESS);
+        
+        address_to_role.set(admin, MANAGER_ROLE);
+
+        let token: TokenInfo = TokenInfo {
+            name: name,
+            symbol: symbol,
+            decimals: decimals,
+            supply: 0u128, // placeholder value; not used
+            max_supply: max_supply
+        };
+
+        token_info.set(TOKEN_INFO_INDEX, token);
+
+        pause.set(PAUSE_STATUS_INDEX, false);
+    }
+
+    // Generates a Credential record for the signer.
+    // Allows future private transfers without needing to re-prove non-inclusion in the freeze list.
+    // The signer's privacy is preserved by proving non-inclusion in the freeze list Merkle tree.
+    async transition get_credentials(sender_merkle_proofs: [MerkleProof;2]) -> (Credentials, Future) {
+        let root: field = verify_non_inclusion(self.signer, sender_merkle_proofs);
+
+        let credentials_record: Credentials = Credentials {
+            owner: self.signer,
+            freeze_list_root: root,
+        };
+
+        return (credentials_record, f_get_credentials(root));
+    }
+    async function f_get_credentials(root: field) {
+        let current_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+        let window: u32 = sealance_freezelist_registry.aleo/block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
+
+        if (current_root != root) {
+            let previous_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+            assert_eq(root, previous_root);
+            let updated_height: u32 = sealance_freezelist_registry.aleo/root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+            assert(updated_height + window > block.height);
+        }
+    }
+
+    // Mints new public tokens to the specified recipient’s balance.
+    // Can only be called by a minter.
+    // Ensures that the new total supply does not exceed the maximum supply.
+    // Updates the recipient’s balance and the total token supply in the token metadata.
+    async transition mint_public(
+        public recipient: address,
+        public amount: u128,
+    ) -> Future {
+        return finalize_mint_public(recipient, amount, self.caller);
+    }
+    async function finalize_mint_public(
+        recipient: address,
+        amount: u128,
+        caller: address
+    ) {
+
+        let role: u16 = address_to_role.get(caller);
+        assert(role & MINTER_ROLE == MINTER_ROLE);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let token = token_info.get(TOKEN_INFO_INDEX);
+        // Check that the token supply + amount <= max_supply
+        let new_supply: u128 = token.supply + amount;
+        assert(new_supply <= token.max_supply);
+
+        // Update the balance
+        let balance = balances.get_or_use(recipient, 0u128);
+        let new_balance = amount + balance;
+        balances.set(recipient, new_balance);
+
+        // Update the token supply
+        let new_metadata: TokenInfo = TokenInfo {
+            name: token.name,
+            symbol: token.symbol,
+            decimals: token.decimals,
+            supply: new_supply,
+            max_supply: token.max_supply,
+        };
+        token_info.set(TOKEN_INFO_INDEX, new_metadata);
+    }
+
+    // Mints new private tokens to the specified recipient.
+    // Can only be called by a minter.
+    // Ensures that the new total supply does not exceed the maximum supply.
+    // Updates the total token supply in the token metadata.
+    async transition mint_private(
+        recipient: address,
+        public amount: u128,
+        ) -> (ComplianceRecord, Token, Future) {
+        let token: Token = Token {
+            owner: recipient,
+            amount: amount,
+        };
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: INVESTIGATOR_ADDRESS,
+            amount: amount,
+            sender: ZERO_ADDRESS,
+            recipient: recipient,
+        };
+        
+        return (compliance_record, token, finalize_mint_private(amount, self.caller));
+    }
+
+    async function finalize_mint_private(
+        amount: u128,
+        caller: address,
+    ) {
+        let role: u16 = address_to_role.get(caller);
+        assert(role & MINTER_ROLE == MINTER_ROLE);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let token = token_info.get(TOKEN_INFO_INDEX);
+
+        // Check that the token supply + amount <= max_supply
+        let new_supply: u128 = token.supply + amount;
+        assert(new_supply <= token.max_supply);
+
+        // Update the token supply
+        let new_metadata: TokenInfo = TokenInfo {
+            name: token.name,
+            symbol: token.symbol,
+            decimals: token.decimals,
+            supply: new_supply,
+            max_supply: token.max_supply,
+        };
+        token_info.set(TOKEN_INFO_INDEX, new_metadata);
+    }
+
+    // Burns public tokens from the specified owner’s balance.
+    // Can only be called by a burner.
+    // Decreases the owner’s balance and reduces the total token supply in the token metadata.
+    async transition burn_public(
+        public owner: address,
+        public amount: u128
+    ) -> Future {
+        return finalize_burn_public(owner, amount, self.caller);
+    }
+
+    async function finalize_burn_public(
+        owner: address,
+        amount: u128,
+        caller: address,
+    ) {
+        let role: u16 = address_to_role.get(caller);
+        assert(role & BURNER_ROLE == BURNER_ROLE);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        // Update the balance
+        let balance = balances.get(owner);
+        let new_balance = balance - amount;
+        balances.set(owner, new_balance);
+
+        let token = token_info.get(TOKEN_INFO_INDEX);
+
+        let new_metadata: TokenInfo = TokenInfo {
+            name: token.name,
+            symbol: token.symbol,
+            decimals: token.decimals,
+            supply: token.supply - amount, // underflow will be caught by the VM
+            max_supply: token.max_supply,
+        };
+        token_info.set(TOKEN_INFO_INDEX, new_metadata);
+    }
+
+    // Burns tokens from a private record (non-public asset).
+    // Can only be called by a burner.
+    // Reduces the amount in the provided private record and decreases the total token supply in the token metadata.
+    async transition burn_private(
+        input_record: Token,
+        public amount: u128
+    ) -> (ComplianceRecord, Token, Future) {
+        let output_record: Token = Token {
+            owner: input_record.owner,
+            amount: input_record.amount - amount
+        };
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: INVESTIGATOR_ADDRESS,
+            amount: amount,
+            sender: input_record.owner,
+            recipient: ZERO_ADDRESS,
+        };
+
+        return (compliance_record, output_record, finalize_burn_private(amount, self.caller));
+    }
+    async function finalize_burn_private(
+        amount: u128,
+        caller: address,
+    ) {
+        let role: u16 = address_to_role.get(caller);
+        assert(role & BURNER_ROLE == BURNER_ROLE);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let token = token_info.get(TOKEN_INFO_INDEX);
+
+        // Update the token supply
+        let new_metadata: TokenInfo = TokenInfo {
+            name: token.name,
+            symbol: token.symbol,
+            decimals: token.decimals,
+            supply: token.supply - amount, // underflow will be caught by the VM
+            max_supply: token.max_supply,
+        };
+        token_info.set(TOKEN_INFO_INDEX, new_metadata);
+    }
+
+    // -------------------------
+    // Called by token owners/DeFi contracts
+    // -------------------------
+
+    // Transfers public tokens from the caller to the recipient.
+    // Both sender and recipient must not be frozen in the freeze list.
+    async transition transfer_public(
+        public recipient: address,
+        public amount: u128
+    ) -> Future {
+        return finalize_transfer_public(recipient, amount, self.caller);
+    }
+
+    async function finalize_transfer_public(
+        recipient: address,
+        amount: u128,
+        sender: address
+    ) {
+        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
+        assert_eq(is_sender_frozen, false);
+        let is_recipient_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(recipient, false);
+        assert_eq(is_recipient_frozen, false);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let sender_balance = balances.get(sender);
+        balances.set(sender, sender_balance - amount);
+
+        let recipient_balance = balances.get_or_use(recipient, 0u128);
+        balances.set(recipient, recipient_balance + amount);
+    }
+
+    // Transfers public tokens from the signer to the recipient.
+    // Both sender and recipient must not be frozen in the freeze list.
+    async transition transfer_public_as_signer(
+        public recipient: address,
+        public amount: u128
+    ) -> Future {
+        return f_transfer_public_as_signer(recipient, amount, self.signer);
+    }
+
+    async function f_transfer_public_as_signer(
+        recipient: address,
+        amount: u128,
+        sender: address
+    ) {
+        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
+        assert_eq(is_sender_frozen, false);
+        let is_recipient_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(recipient, false);
+        assert_eq(is_recipient_frozen, false);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let sender_balance = balances.get(sender);
+        balances.set(sender, sender_balance - amount);
+
+        let recipient_balance = balances.get_or_use(recipient, 0u128);
+        balances.set(recipient, recipient_balance + amount);
+    }
+
+    // Approves a spender to transfer the caller’s public assets up to a specified amount.
+    // Increases the existing allowance if one is already set, otherwise creates a new allowance.
+    // The allowance is stored using a hash of the owner–spender pair as the key.
+    async transition approve_public(
+        public spender: address,
+        public amount: u128
+    ) -> Future {
+        let allowance: TokenAllowance = TokenAllowance {
+            account: self.caller,
+            spender: spender
+        };
+        let allowance_key: field = BHP256::hash_to_field(allowance);
+
+        return finalize_approve_public(amount, allowance_key);
+    }
+
+    async function finalize_approve_public(
+        amount: u128,
+        allowance_key: field
+    ) {
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let current_allowance: u128 = allowances.get_or_use(allowance_key, 0u128);
+        // Increase or create the allowance amount
+        allowances.set(allowance_key, current_allowance + amount);
+    }
+
+    // Reduces a spender’s allowance to transfer the caller’s public assets by a specified amount.
+    // Decreases the existing allowance stored under the hash of the owner–spender pair.
+    // If the reduction exceeds the current allowance, the VM will catch the underflow.
+    async transition unapprove_public(
+        public spender: address,
+        public amount: u128
+    ) -> Future {
+        let allowance: TokenAllowance = TokenAllowance {
+            account: self.caller,
+            spender: spender
+        };
+        let allowance_key: field = BHP256::hash_to_field(allowance);
+
+        return finalize_unapprove_public(amount, allowance_key);
+    }
+    async function finalize_unapprove_public(
+        amount: u128,
+        allowance_key: field
+    ) {
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let current_allowance: u128 = allowances.get(allowance_key);
+        // Decrease the allowance amount
+        allowances.set(allowance_key, current_allowance - amount);
+    }
+
+    // Transfers public tokens from the owner to the recipient.
+    // Can be called by any spender with sufficient allowance from the owner.
+    // Decreases the spender’s allowance by the transferred amount.
+    // Both sender and recipient must not be frozen in the freeze list.
+    async transition transfer_from_public(
+        public owner: address,
+        public recipient: address,
+        public amount: u128
+    ) -> Future {
+        let allowance: TokenAllowance = TokenAllowance {
+            account: owner,
+            spender: self.caller,
+        };
+        let allowance_key: field = BHP256::hash_to_field(allowance);
+
+        return finalize_transfer_from_public(owner, recipient, amount, allowance_key);
+    }
+
+    async function finalize_transfer_from_public(
+        sender: address,
+        recipient: address,
+        amount: u128,
+        allowance_key: field
+    ) {
+        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
+        assert_eq(is_sender_frozen, false);
+        let is_recipient_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(recipient, false);
+        assert_eq(is_recipient_frozen, false);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        // Check that the spender is authorized to spend the amount
+        let current_allowance: u128 = allowances.get(allowance_key);
+        // Decrease the allowance by the amount being spent
+        allowances.set(allowance_key, current_allowance - amount);
+
+        let sender_balance = balances.get(sender);
+        balances.set(sender, sender_balance - amount);
+
+        let recipient_balance = balances.get_or_use(recipient, 0u128);
+        balances.set(recipient, recipient_balance + amount);
+    }
+
+    // Transfers public tokens from the caller to a recipient as a private token.
+    // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
+    // The sender must not be frozen in the freeze list.
+    async transition transfer_public_to_private(
+        recipient: address,
+        public amount: u128,
+    ) -> (ComplianceRecord, Token, Future) {
+        let token: Token = Token {
+            owner: recipient,
+            amount: amount
+        };
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: INVESTIGATOR_ADDRESS,
+            amount: amount,
+            sender: self.caller,
+            recipient: recipient,
+        };
+
+        return (compliance_record, token, f_transfer_public_to_private(amount, self.caller));
+    }
+
+    async function f_transfer_public_to_private(
+        amount: u128,
+        sender: address,
+    ) {
+        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
+        assert_eq(is_sender_frozen, false);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let sender_balance = balances.get(sender);
+        balances.set(sender, sender_balance - amount);
+    }
+
+    // Transfers public tokens from an owner to a recipient as a private token.
+    // Can be called by any spender with sufficient allowance from the owner.
+    // Decreases the spender’s allowance by the transferred amount.
+    // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
+    // The sender must not be frozen in the freeze list.
+    async transition transfer_from_public_to_private(
+        public owner: address,
+        recipient: address,
+        public amount: u128,
+    ) -> (ComplianceRecord, Token, Future) {
+
+        let token: Token = Token {
+            owner: recipient,
+            amount: amount
+        };
+
+        let allowance: TokenAllowance = TokenAllowance {
+            account: owner,
+            spender: self.caller,
+        };
+        let allowance_key: field = BHP256::hash_to_field(allowance);
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: INVESTIGATOR_ADDRESS,
+            amount: amount,
+            sender: owner,
+            recipient: recipient,
+        };
+
+        return (compliance_record, token, f_transfer_from_public_to_priv(owner, amount, allowance_key));
+    }
+
+    async function f_transfer_from_public_to_priv(
+        sender: address,
+        amount: u128,
+        allowance_key: field,
+    ) {
+        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
+        assert_eq(is_sender_frozen, false);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        // Check that the spender is authorized to spend the amount
+        let current_allowance: u128 = allowances.get(allowance_key);
+        // Decrease the allowance by the amount being spent
+        allowances.set(allowance_key, current_allowance - amount);
+
+        let sender_balance = balances.get(sender);
+        balances.set(sender, sender_balance - amount);
+    }
+
+    // Transfers private tokens from the record owner to a recipient.
+    // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
+    // The sender must not be frozen in the freeze list.
+    // The sender's privacy is preserved by proving non-inclusion in the freeze list Merkle tree.
+    async transition transfer_private(
+        recipient: address,
+        amount: u128,
+        input_record: Token,
+        sender_merkle_proofs: [MerkleProof;2],
+    ) -> (ComplianceRecord, Token, Token, Future) {
+        let sender_root: field = verify_non_inclusion(input_record.owner, sender_merkle_proofs);
+
+        let updated_record: Token = Token {
+            owner: input_record.owner,
+            amount: input_record.amount - amount
+        };
+
+        let transfer_record: Token = Token {
+            owner: recipient,
+            amount: amount
+        };
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: INVESTIGATOR_ADDRESS,
+            amount: amount,
+            sender: input_record.owner,
+            recipient: recipient,
+        };
+
+        return (compliance_record, updated_record, transfer_record, f_transfer_private(sender_root));
+    }
+
+    async function f_transfer_private(root: field) {
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let current_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+        let window: u32 = sealance_freezelist_registry.aleo/block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
+
+        if (current_root != root) {
+            let previous_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+            assert_eq(root, previous_root);
+            let updated_height: u32 = sealance_freezelist_registry.aleo/root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+            assert(updated_height + window > block.height);
+        }
+    }
+
+    // Transfers private tokens from the record owner to a recipient as a public tokens.
+    // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
+    // A Credentials record is emitted for the sender
+    // Both sender and recipient must not be frozen in the freeze list.
+    // The sender's privacy is preserved by proving non-inclusion in the freeze list Merkle tree.
+    async transition transfer_private_to_public(
+        public recipient: address,
+        public amount: u128,
+        input_record: Token,
+        sender_merkle_proofs: [MerkleProof; 2],
+    ) -> (ComplianceRecord, Token, Future) {
+        let root: field = verify_non_inclusion(input_record.owner, sender_merkle_proofs);
+
+        let updated_record: Token = Token {
+            owner: input_record.owner,
+            amount: input_record.amount - amount
+        };
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: INVESTIGATOR_ADDRESS,
+            amount: amount,
+            sender: input_record.owner,
+            recipient: recipient,
+        };
+
+        return (
+            compliance_record,
+            updated_record,
+            f_transfer_private_to_public(
+                root,
+                recipient,
+                amount
+            )
+        );
+    }
+
+    async function f_transfer_private_to_public(
+        root: field,
+        recipient: address,
+        amount: u128    ) {
+        
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let current_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+        let window: u32 = sealance_freezelist_registry.aleo/block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
+
+        if (current_root != root) {
+            let previous_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+            assert_eq(root, previous_root);
+            let updated_height: u32 = sealance_freezelist_registry.aleo/root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+            assert(updated_height + window > block.height);
+        } 
+
+        let is_recipient_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(recipient, false);
+        assert_eq(is_recipient_frozen, false);
+
+        let recipient_balance = balances.get_or_use(recipient, 0u128);
+        balances.set(recipient, recipient_balance + amount);
+    }
+
+    // Stops or resumes all token transfers.
+    // Can only be called by an address with the PAUSE_ROLE.
+    async transition set_pause_status(pause_status: bool) -> Future {
+        return f_set_pause_status(pause_status, self.caller);
+    }
+
+    async function f_set_pause_status(new_pause_status: bool, caller: address) {
+        let role: u16 = address_to_role.get(caller);
+        assert(role & PAUSE_ROLE == PAUSE_ROLE);
+        
+        pause.set(PAUSE_STATUS_INDEX, new_pause_status);
+    }
+
+
+    transition join(
+        private token_1: Token,
+        private token_2: Token
+    ) -> Token {
+        let new_token: Token = Token {
+            owner: token_1.owner,
+            amount: token_1.amount + token_2.amount
+        };
+
+        return new_token;
+    }
+
+    transition split(
+        private token: Token,
+        private amount: u128
+    ) -> (Token, Token) {
+        let new_token_1: Token = Token {
+            owner: token.owner,
+            amount: amount
+        };
+        let new_token_2: Token = Token {
+            owner: token.owner,
+            amount: token.amount - amount
+        };
+
+        return (new_token_1, new_token_2);
+    }
+
+    // Transfers private tokens from the record owner to a recipient.
+    // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
+    // The sender must not be frozen in the freeze list.
+    // The sender's privacy is preserved by using a Credentials record.
+    async transition transfer_private_with_creds(
+        recipient: address,
+        amount: u128,
+        input_record: Token,
+        credentials: Credentials,
+    ) -> (ComplianceRecord, Token, Token, Credentials, Future) {
+        let updated_record: Token = Token {
+            owner: input_record.owner,
+            amount: input_record.amount - amount
+        };
+
+        let transfer_record: Token = Token {
+            owner: recipient,
+            amount: amount
+        };
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: INVESTIGATOR_ADDRESS,
+            amount: amount,
+            sender: input_record.owner,
+            recipient: recipient,
+        };
+
+        let credentials_record: Credentials = Credentials {
+            owner: credentials.owner,
+            freeze_list_root: credentials.freeze_list_root,
+        };
+
+        return (compliance_record, updated_record, transfer_record, credentials_record, f_transfer_private_credentials(credentials.freeze_list_root));
+    }
+
+    async function f_transfer_private_credentials(root: field) {
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let current_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+        let window: u32 = sealance_freezelist_registry.aleo/block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
+
+        if (current_root != root) {
+            let previous_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+            assert_eq(root, previous_root);
+            let updated_height: u32 = sealance_freezelist_registry.aleo/root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+            assert(updated_height + window > block.height);
+        }
+    }
+
+    // Calculates the hash of two sibling nodes in a Merkle tree.
+    // The order of the siblings depends on the index bit (0 = left, 1 = right).
+    // Uses Poseidon hash to compute the result.
+    inline calculate_hash_for_nodes(sibling1: field, sibling2: field, indexbit: u32) -> field {
+        let poseidon_params: [field; 3] = indexbit == 0u32 ? [0field, sibling1, sibling2] : [0field, sibling2, sibling1];
+        return Poseidon4::hash_to_field(poseidon_params);
+    }
+
+    inline calculate_hash_for_leaves(sibling1: field, sibling2: field, indexbit: u32) -> field {
+        let poseidon_params: [field; 3] = indexbit == 0u32 ? [1field, sibling1, sibling2] : [1field, sibling2, sibling1];
+        return Poseidon4::hash_to_field(poseidon_params);
+    }
+
+    // Calculates the Merkle root and the depth of a Merkle proof path.
+    // Iteratively hashes the sibling path based on the leaf index to reconstruct the root.
+    // Stops when a zero field is encountered in the siblings array, indicating the end of the valid path.
+    // Returns the calculated root and the actual depth reached.
+    inline calculate_root_depth_siblings(merkle_proof: MerkleProof) -> (public field, public u32) {
+        let root: field = calculate_hash_for_leaves(merkle_proof.siblings[0u8], merkle_proof.siblings[1u8],  merkle_proof.leaf_index % 2u32);
+        for i: u32 in 2u32..MAX_TREE_DEPTH + 1u32 {
+            if (merkle_proof.siblings[i] == 0field) {
+                return (root, i - 1u32);
+            }
+            root = calculate_hash_for_nodes(root, merkle_proof.siblings[i], (merkle_proof.leaf_index / (2u32**(i-1u32))) % 2u32);
+        }
+        return (root, MAX_TREE_DEPTH);
+    }
+
+    // Verifies non-inclusion of an address in a Merkle tree sorted in ascending order by address (as field).
+    // Accepts two Merkle proofs representing the neighboring leaves around the missing address.
+    // Returns the common Merkle root if the address is proven to be outside the tree.
+    // If the tree is not sorted correctly, this function may return incorrect results.
+    inline verify_non_inclusion(addr: address, merkle_proofs: [MerkleProof;2]) -> field {
+        let (root1, depth1): (field, u32)= calculate_root_depth_siblings(merkle_proofs[0u32]);
+        let (root2, depth2): (field, u32) = calculate_root_depth_siblings(merkle_proofs[1u32]);
+
+        // Ensure the roots from the merkle proofs are the same
+        assert_eq(root1, root2);
+        // Ensure the depth of the merkle proofs is the same
+        assert_eq(depth1, depth2);
+        
+        let addr_field: field = addr as field;
+        if (merkle_proofs[0u32].leaf_index == merkle_proofs[1u32].leaf_index) {
+            // Ensure that if the address is the most left leaf, it is less than the first sibling
+            if (merkle_proofs[0u32].leaf_index == 0u32) {
+                assert(addr_field < merkle_proofs[0u32].siblings[0u32]);
+            } else {
+                // Ensure that if the address is the most right leaf
+                let last_index_leaf: u32 = 2u32 ** depth1 - 1u32;
+                assert_eq(merkle_proofs[0u32].leaf_index, last_index_leaf);
+                // Ensure that the address is bigger than the first sibling
+                assert(addr_field > merkle_proofs[0u32].siblings[0u32]);
+            }
+        } else {
+            // Ensure the address is in between the provided leaves
+            assert(addr_field > merkle_proofs[0u32].siblings[0u32]);
+            assert(addr_field < merkle_proofs[1u32].siblings[0u32]);
+            // Ensure that the leaf indexes are not greater than the last possible leaf index
+            let last_index_leaf: u32 = 2u32 ** depth1 - 1u32;
+            assert(merkle_proofs[1u32].leaf_index <= last_index_leaf);
+            // Ensure the leaves are adjacent
+            assert_eq(merkle_proofs[0u32].leaf_index + 1u32, merkle_proofs[1u32].leaf_index);
+        }
+        
+        return root1;
+    }
+}

--- a/programs/amm/lp_token.leo
+++ b/programs/amm/lp_token.leo
@@ -1,22 +1,112 @@
 import sealance_freezelist_registry.aleo;
 import multisig_core.aleo;
 
+struct MerkleProof {
+    siblings: [field; 16],
+    leaf_index: u32
+}
+
+struct ChecksumEdition {
+    checksum: [u8; 32],
+    edition: u16,
+}
+
+struct TokenInfo {
+    name: u128, // ASCII text represented in bits, and the u128 value of the bitstring
+    symbol: u128, // ASCII text represented in bits, and the u128 value of the bitstring
+    decimals: u8,
+    supply: u128,
+    max_supply: u128,
+}
+
+struct TokenAllowance {
+    account: address,
+    spender: address,
+}
+
+// Calculates the hash of two sibling nodes in a Merkle tree.
+// The order of the siblings depends on the index bit (0 = left, 1 = right).
+// Uses Poseidon hash to compute the result.
+fn calculate_hash_for_nodes(sibling1: field, sibling2: field, indexbit: u32) -> field {
+    let poseidon_params: [field; 3] = indexbit == 0u32 ? [0field, sibling1, sibling2] : [0field, sibling2, sibling1];
+    return Poseidon4::hash_to_field(poseidon_params);
+}
+
+fn calculate_hash_for_leaves(sibling1: field, sibling2: field, indexbit: u32) -> field {
+    let poseidon_params: [field; 3] = indexbit == 0u32 ? [1field, sibling1, sibling2] : [1field, sibling2, sibling1];
+    return Poseidon4::hash_to_field(poseidon_params);
+}
+
+// Calculates the Merkle root and the depth of a Merkle proof path.
+// Iteratively hashes the sibling path based on the leaf index to reconstruct the root.
+// Stops when a zero field is encountered in the siblings array, indicating the end of the valid path.
+// Returns the calculated root and the actual depth reached.
+fn calculate_root_depth_siblings(merkle_proof: MerkleProof) -> (public field, public u32) {
+    let root: field = calculate_hash_for_leaves(merkle_proof.siblings[0u8], merkle_proof.siblings[1u8],  merkle_proof.leaf_index % 2u32);
+    for i: u32 in 2u32..MAX_TREE_DEPTH + 1u32 {
+        if (merkle_proof.siblings[i] == 0field) {
+            return (root, i - 1u32);
+        }
+        root = calculate_hash_for_nodes(root, merkle_proof.siblings[i], (merkle_proof.leaf_index / (2u32**(i-1u32))) % 2u32);
+    }
+    return (root, MAX_TREE_DEPTH);
+}
+
+// Verifies non-inclusion of an address in a Merkle tree sorted in ascending order by address (as field).
+// Accepts two Merkle proofs representing the neighboring leaves around the missing address.
+// Returns the common Merkle root if the address is proven to be outside the tree.
+// If the tree is not sorted correctly, this function may return incorrect results.
+fn verify_non_inclusion(addr: address, merkle_proofs: [MerkleProof;2]) -> field {
+    let (root1, depth1): (field, u32)= calculate_root_depth_siblings(merkle_proofs[0u32]);
+    let (root2, depth2): (field, u32) = calculate_root_depth_siblings(merkle_proofs[1u32]);
+
+    // Ensure the roots from the merkle proofs are the same
+    assert_eq(root1, root2);
+    // Ensure the depth of the merkle proofs is the same
+    assert_eq(depth1, depth2);
+
+    let addr_field: field = addr as field;
+    if (merkle_proofs[0u32].leaf_index == merkle_proofs[1u32].leaf_index) {
+        // Ensure that if the address is the most left leaf, it is less than the first sibling
+        if (merkle_proofs[0u32].leaf_index == 0u32) {
+            assert(addr_field < merkle_proofs[0u32].siblings[0u32]);
+        } else {
+            // Ensure that if the address is the most right leaf
+            let last_index_leaf: u32 = 2u32 ** depth1 - 1u32;
+            assert_eq(merkle_proofs[0u32].leaf_index, last_index_leaf);
+            // Ensure that the address is bigger than the first sibling
+            assert(addr_field > merkle_proofs[0u32].siblings[0u32]);
+        }
+    } else {
+        // Ensure the address is in between the provided leaves
+        assert(addr_field > merkle_proofs[0u32].siblings[0u32]);
+        assert(addr_field < merkle_proofs[1u32].siblings[0u32]);
+        // Ensure that the leaf indexes are not greater than the last possible leaf index
+        let last_index_leaf: u32 = 2u32 ** depth1 - 1u32;
+        assert(merkle_proofs[1u32].leaf_index <= last_index_leaf);
+        // Ensure the leaves are adjacent
+        assert_eq(merkle_proofs[0u32].leaf_index + 1u32, merkle_proofs[1u32].leaf_index);
+    }
+
+    return root1;
+}
+
 program lp_token.aleo {
     @custom
-    async constructor() {
+    constructor() {
         // Only require multisig for upgrades - initial deployment has no checks.
         if self.edition > 0u16 {
             let signing_op_id = BHP256::hash_to_field(ChecksumEdition { checksum: self.checksum, edition: self.edition });
 
-            let wallet_signing_op_id_hash = BHP256::hash_to_field(multisig_core.aleo/WalletSigningOpId { wallet_id: self.address, signing_op_id: signing_op_id });
-            let signing_complete = multisig_core.aleo/completed_signing_ops.contains(wallet_signing_op_id_hash);
+            let wallet_signing_op_id_hash = BHP256::hash_to_field(multisig_core.aleo::WalletSigningOpId { wallet_id: self.address, signing_op_id: signing_op_id });
+            let signing_complete = multisig_core.aleo::completed_signing_ops.contains(wallet_signing_op_id_hash);
             assert(signing_complete);
         }
     }
 
     // A helper for calculating a signing_op_id from the program's checksum and edition.
     // By deriving the signing_op_id from both we ensure that downgrades cannot take place.
-    transition get_signing_op_id_for_deploy(checksum: [u8; 32], edition: u16) -> field {
+    fn get_signing_op_id_for_deploy(checksum: [u8; 32], edition: u16) -> field {
         return BHP256::hash_to_field(ChecksumEdition { checksum: checksum, edition: edition });
     }
 
@@ -38,29 +128,6 @@ program lp_token.aleo {
         freeze_list_root: field,
     }
 
-    struct MerkleProof {
-        siblings: [field; 16],
-        leaf_index: u32
-    }
-
-    struct ChecksumEdition {
-        checksum: [u8; 32],
-        edition: u16,
-    }
-
-    struct TokenInfo {
-        name: u128, // ASCII text represented in bits, and the u128 value of the bitstring
-        symbol: u128, // ASCII text represented in bits, and the u128 value of the bitstring
-        decimals: u8,
-        supply: u128,
-        max_supply: u128,
-    }
-
-    struct TokenAllowance {
-        account: address,
-        spender: address,
-    }
-    
     const TOKEN_INFO_INDEX: bool = true;
     // token specs
     mapping token_info: bool => TokenInfo;
@@ -101,76 +168,61 @@ program lp_token.aleo {
 
     // Updates the address assigned to a given role.
     // Can only be called by the current role manager.
-    async transition update_role(public new_address: address, role: u16) -> Future {
-        return f_update_role(new_address, self.caller, role);
-    }
-    async function f_update_role(new_address: address, caller: address, new_role: u16) {
-        let current_role: u16 = address_to_role.get(caller);
-        assert(current_role & MANAGER_ROLE == MANAGER_ROLE);
-        
-        if (caller == new_address) { 
-            assert(new_role & MANAGER_ROLE == MANAGER_ROLE); 
-        }
+    fn update_role(public new_address: address, role: u16) -> Final {
+        let caller: address = self.caller;
+        return final {
+            let current_role: u16 = address_to_role.get(caller);
+            assert(current_role & MANAGER_ROLE == MANAGER_ROLE);
 
-        address_to_role.set(new_address, new_role);
+            if (caller == new_address) {
+                assert(role & MANAGER_ROLE == MANAGER_ROLE);
+            }
 
+            address_to_role.set(new_address, role);
+        };
     }
 
     // Initializes the freeze list, token specifications, the admin and the investigator.
-    // Can be called only once and only by the INITIAL_ADMIN    
+    // Can be called only once and only by the INITIAL_ADMIN
     // Sets the token metadata (name, symbol, decimals, max supply).
     // Sets the block height window, the initial empty Merkle root,
     // and initialize the freeze_list_last_index, freeze_list, and freeze_list_index with a ZERO_ADDRESS placeholder.
-    async transition initialize(
+    fn initialize(
         public name: u128,
         public symbol: u128,
         public decimals: u8,
         public max_supply: u128,
         public admin: address,
-    ) -> Future {
-        return finalize_initialize(
-            name,
-            symbol,
-            decimals,
-            max_supply,
-            admin,
-            self.caller,
-        );
-    }
-    async function finalize_initialize(
-        name: u128,
-        symbol: u128,
-        decimals: u8,
-        max_supply: u128,
-        admin: address, 
-        caller: address,
-    ) {
-        // Check if the token has already been initialized
-        let already_initialized: bool = token_info.contains(TOKEN_INFO_INDEX);
-        assert_eq(already_initialized, false);
-        
-        // Only the INITIAL_CONFIGURATION_ADDRESS can initialize the contract
-        assert_eq(caller, DEPLOYER_ADDRESS);
-        
-        address_to_role.set(admin, MANAGER_ROLE);
+    ) -> Final {
+        let caller: address = self.caller;
+        return final {
+            // Check if the token has already been initialized
+            let already_initialized: bool = token_info.contains(TOKEN_INFO_INDEX);
+            assert_eq(already_initialized, false);
 
-        let token: TokenInfo = TokenInfo {
-            name: name,
-            symbol: symbol,
-            decimals: decimals,
-            supply: 0u128, // placeholder value; not used
-            max_supply: max_supply
+            // Only the INITIAL_CONFIGURATION_ADDRESS can initialize the contract
+            assert_eq(caller, DEPLOYER_ADDRESS);
+
+            address_to_role.set(admin, MANAGER_ROLE);
+
+            let token: TokenInfo = TokenInfo {
+                name: name,
+                symbol: symbol,
+                decimals: decimals,
+                supply: 0u128, // placeholder value; not used
+                max_supply: max_supply
+            };
+
+            token_info.set(TOKEN_INFO_INDEX, token);
+
+            pause.set(PAUSE_STATUS_INDEX, false);
         };
-
-        token_info.set(TOKEN_INFO_INDEX, token);
-
-        pause.set(PAUSE_STATUS_INDEX, false);
     }
 
     // Generates a Credential record for the signer.
     // Allows future private transfers without needing to re-prove non-inclusion in the freeze list.
     // The signer's privacy is preserved by proving non-inclusion in the freeze list Merkle tree.
-    async transition get_credentials(sender_merkle_proofs: [MerkleProof;2]) -> (Credentials, Future) {
+    fn get_credentials(sender_merkle_proofs: [MerkleProof;2]) -> (Credentials, Final) {
         let root: field = verify_non_inclusion(self.signer, sender_merkle_proofs);
 
         let credentials_record: Credentials = Credentials {
@@ -178,71 +230,65 @@ program lp_token.aleo {
             freeze_list_root: root,
         };
 
-        return (credentials_record, f_get_credentials(root));
-    }
-    async function f_get_credentials(root: field) {
-        let current_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
-        let window: u32 = sealance_freezelist_registry.aleo/block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
+        return (credentials_record, final {
+            let current_root: field = sealance_freezelist_registry.aleo::freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+            let window: u32 = sealance_freezelist_registry.aleo::block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
 
-        if (current_root != root) {
-            let previous_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
-            assert_eq(root, previous_root);
-            let updated_height: u32 = sealance_freezelist_registry.aleo/root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
-            assert(updated_height + window > block.height);
-        }
+            if (current_root != root) {
+                let previous_root: field = sealance_freezelist_registry.aleo::freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+                assert_eq(root, previous_root);
+                let updated_height: u32 = sealance_freezelist_registry.aleo::root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+                assert(updated_height + window > block.height);
+            }
+        });
     }
 
-    // Mints new public tokens to the specified recipient’s balance.
+    // Mints new public tokens to the specified recipient's balance.
     // Can only be called by a minter.
     // Ensures that the new total supply does not exceed the maximum supply.
-    // Updates the recipient’s balance and the total token supply in the token metadata.
-    async transition mint_public(
+    // Updates the recipient's balance and the total token supply in the token metadata.
+    fn mint_public(
         public recipient: address,
         public amount: u128,
-    ) -> Future {
-        return finalize_mint_public(recipient, amount, self.caller);
-    }
-    async function finalize_mint_public(
-        recipient: address,
-        amount: u128,
-        caller: address
-    ) {
+    ) -> Final {
+        let caller: address = self.caller;
+        return final {
+            let role: u16 = address_to_role.get(caller);
+            assert(role & MINTER_ROLE == MINTER_ROLE);
 
-        let role: u16 = address_to_role.get(caller);
-        assert(role & MINTER_ROLE == MINTER_ROLE);
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
+            let token = token_info.get(TOKEN_INFO_INDEX);
+            // Check that the token supply + amount <= max_supply
+            let new_supply: u128 = token.supply + amount;
+            assert(new_supply <= token.max_supply);
 
-        let token = token_info.get(TOKEN_INFO_INDEX);
-        // Check that the token supply + amount <= max_supply
-        let new_supply: u128 = token.supply + amount;
-        assert(new_supply <= token.max_supply);
+            // Update the balance
+            let balance = balances.get_or_use(recipient, 0u128);
+            let new_balance = amount + balance;
+            balances.set(recipient, new_balance);
 
-        // Update the balance
-        let balance = balances.get_or_use(recipient, 0u128);
-        let new_balance = amount + balance;
-        balances.set(recipient, new_balance);
-
-        // Update the token supply
-        let new_metadata: TokenInfo = TokenInfo {
-            name: token.name,
-            symbol: token.symbol,
-            decimals: token.decimals,
-            supply: new_supply,
-            max_supply: token.max_supply,
+            // Update the token supply
+            let new_metadata: TokenInfo = TokenInfo {
+                name: token.name,
+                symbol: token.symbol,
+                decimals: token.decimals,
+                supply: new_supply,
+                max_supply: token.max_supply,
+            };
+            token_info.set(TOKEN_INFO_INDEX, new_metadata);
         };
-        token_info.set(TOKEN_INFO_INDEX, new_metadata);
     }
 
     // Mints new private tokens to the specified recipient.
     // Can only be called by a minter.
     // Ensures that the new total supply does not exceed the maximum supply.
     // Updates the total token supply in the token metadata.
-    async transition mint_private(
+    fn mint_private(
         recipient: address,
         public amount: u128,
-        ) -> (ComplianceRecord, Token, Future) {
+        ) -> (ComplianceRecord, Token, Final) {
         let token: Token = Token {
             owner: recipient,
             amount: amount,
@@ -254,82 +300,73 @@ program lp_token.aleo {
             sender: ZERO_ADDRESS,
             recipient: recipient,
         };
-        
-        return (compliance_record, token, finalize_mint_private(amount, self.caller));
+
+        let caller: address = self.caller;
+        return (compliance_record, token, final {
+            let role: u16 = address_to_role.get(caller);
+            assert(role & MINTER_ROLE == MINTER_ROLE);
+
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
+
+            let token_metadata = token_info.get(TOKEN_INFO_INDEX);
+
+            // Check that the token supply + amount <= max_supply
+            let new_supply: u128 = token_metadata.supply + amount;
+            assert(new_supply <= token_metadata.max_supply);
+
+            // Update the token supply
+            let new_metadata: TokenInfo = TokenInfo {
+                name: token_metadata.name,
+                symbol: token_metadata.symbol,
+                decimals: token_metadata.decimals,
+                supply: new_supply,
+                max_supply: token_metadata.max_supply,
+            };
+            token_info.set(TOKEN_INFO_INDEX, new_metadata);
+        });
     }
 
-    async function finalize_mint_private(
-        amount: u128,
-        caller: address,
-    ) {
-        let role: u16 = address_to_role.get(caller);
-        assert(role & MINTER_ROLE == MINTER_ROLE);
-
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
-
-        let token = token_info.get(TOKEN_INFO_INDEX);
-
-        // Check that the token supply + amount <= max_supply
-        let new_supply: u128 = token.supply + amount;
-        assert(new_supply <= token.max_supply);
-
-        // Update the token supply
-        let new_metadata: TokenInfo = TokenInfo {
-            name: token.name,
-            symbol: token.symbol,
-            decimals: token.decimals,
-            supply: new_supply,
-            max_supply: token.max_supply,
-        };
-        token_info.set(TOKEN_INFO_INDEX, new_metadata);
-    }
-
-    // Burns public tokens from the specified owner’s balance.
+    // Burns public tokens from the specified owner's balance.
     // Can only be called by a burner.
-    // Decreases the owner’s balance and reduces the total token supply in the token metadata.
-    async transition burn_public(
+    // Decreases the owner's balance and reduces the total token supply in the token metadata.
+    fn burn_public(
         public owner: address,
         public amount: u128
-    ) -> Future {
-        return finalize_burn_public(owner, amount, self.caller);
-    }
+    ) -> Final {
+        let caller: address = self.caller;
+        return final {
+            let role: u16 = address_to_role.get(caller);
+            assert(role & BURNER_ROLE == BURNER_ROLE);
 
-    async function finalize_burn_public(
-        owner: address,
-        amount: u128,
-        caller: address,
-    ) {
-        let role: u16 = address_to_role.get(caller);
-        assert(role & BURNER_ROLE == BURNER_ROLE);
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
+            // Update the balance
+            let balance = balances.get(owner);
+            let new_balance = balance - amount;
+            balances.set(owner, new_balance);
 
-        // Update the balance
-        let balance = balances.get(owner);
-        let new_balance = balance - amount;
-        balances.set(owner, new_balance);
+            let token = token_info.get(TOKEN_INFO_INDEX);
 
-        let token = token_info.get(TOKEN_INFO_INDEX);
-
-        let new_metadata: TokenInfo = TokenInfo {
-            name: token.name,
-            symbol: token.symbol,
-            decimals: token.decimals,
-            supply: token.supply - amount, // underflow will be caught by the VM
-            max_supply: token.max_supply,
+            let new_metadata: TokenInfo = TokenInfo {
+                name: token.name,
+                symbol: token.symbol,
+                decimals: token.decimals,
+                supply: token.supply - amount, // underflow will be caught by the VM
+                max_supply: token.max_supply,
+            };
+            token_info.set(TOKEN_INFO_INDEX, new_metadata);
         };
-        token_info.set(TOKEN_INFO_INDEX, new_metadata);
     }
 
     // Burns tokens from a private record (non-public asset).
     // Can only be called by a burner.
     // Reduces the amount in the provided private record and decreases the total token supply in the token metadata.
-    async transition burn_private(
+    fn burn_private(
         input_record: Token,
         public amount: u128
-    ) -> (ComplianceRecord, Token, Future) {
+    ) -> (ComplianceRecord, Token, Final) {
         let output_record: Token = Token {
             owner: input_record.owner,
             amount: input_record.amount - amount
@@ -342,29 +379,26 @@ program lp_token.aleo {
             recipient: ZERO_ADDRESS,
         };
 
-        return (compliance_record, output_record, finalize_burn_private(amount, self.caller));
-    }
-    async function finalize_burn_private(
-        amount: u128,
-        caller: address,
-    ) {
-        let role: u16 = address_to_role.get(caller);
-        assert(role & BURNER_ROLE == BURNER_ROLE);
+        let caller: address = self.caller;
+        return (compliance_record, output_record, final {
+            let role: u16 = address_to_role.get(caller);
+            assert(role & BURNER_ROLE == BURNER_ROLE);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-        let token = token_info.get(TOKEN_INFO_INDEX);
+            let token = token_info.get(TOKEN_INFO_INDEX);
 
-        // Update the token supply
-        let new_metadata: TokenInfo = TokenInfo {
-            name: token.name,
-            symbol: token.symbol,
-            decimals: token.decimals,
-            supply: token.supply - amount, // underflow will be caught by the VM
-            max_supply: token.max_supply,
-        };
-        token_info.set(TOKEN_INFO_INDEX, new_metadata);
+            // Update the token supply
+            let new_metadata: TokenInfo = TokenInfo {
+                name: token.name,
+                symbol: token.symbol,
+                decimals: token.decimals,
+                supply: token.supply - amount, // underflow will be caught by the VM
+                max_supply: token.max_supply,
+            };
+            token_info.set(TOKEN_INFO_INDEX, new_metadata);
+        });
     }
 
     // -------------------------
@@ -373,170 +407,142 @@ program lp_token.aleo {
 
     // Transfers public tokens from the caller to the recipient.
     // Both sender and recipient must not be frozen in the freeze list.
-    async transition transfer_public(
+    fn transfer_public(
         public recipient: address,
         public amount: u128
-    ) -> Future {
-        return finalize_transfer_public(recipient, amount, self.caller);
-    }
+    ) -> Final {
+        let caller: address = self.caller;
+        return final {
+            let is_sender_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(caller, false);
+            assert_eq(is_sender_frozen, false);
+            let is_recipient_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(recipient, false);
+            assert_eq(is_recipient_frozen, false);
 
-    async function finalize_transfer_public(
-        recipient: address,
-        amount: u128,
-        sender: address
-    ) {
-        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
-        assert_eq(is_sender_frozen, false);
-        let is_recipient_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(recipient, false);
-        assert_eq(is_recipient_frozen, false);
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
+            let sender_balance = balances.get(caller);
+            balances.set(caller, sender_balance - amount);
 
-        let sender_balance = balances.get(sender);
-        balances.set(sender, sender_balance - amount);
-
-        let recipient_balance = balances.get_or_use(recipient, 0u128);
-        balances.set(recipient, recipient_balance + amount);
+            let recipient_balance = balances.get_or_use(recipient, 0u128);
+            balances.set(recipient, recipient_balance + amount);
+        };
     }
 
     // Transfers public tokens from the signer to the recipient.
     // Both sender and recipient must not be frozen in the freeze list.
-    async transition transfer_public_as_signer(
+    fn transfer_public_as_signer(
         public recipient: address,
         public amount: u128
-    ) -> Future {
-        return f_transfer_public_as_signer(recipient, amount, self.signer);
+    ) -> Final {
+        let signer: address = self.signer;
+        return final {
+            let is_sender_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(signer, false);
+            assert_eq(is_sender_frozen, false);
+            let is_recipient_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(recipient, false);
+            assert_eq(is_recipient_frozen, false);
+
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
+
+            let sender_balance = balances.get(signer);
+            balances.set(signer, sender_balance - amount);
+
+            let recipient_balance = balances.get_or_use(recipient, 0u128);
+            balances.set(recipient, recipient_balance + amount);
+        };
     }
 
-    async function f_transfer_public_as_signer(
-        recipient: address,
-        amount: u128,
-        sender: address
-    ) {
-        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
-        assert_eq(is_sender_frozen, false);
-        let is_recipient_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(recipient, false);
-        assert_eq(is_recipient_frozen, false);
-
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
-
-        let sender_balance = balances.get(sender);
-        balances.set(sender, sender_balance - amount);
-
-        let recipient_balance = balances.get_or_use(recipient, 0u128);
-        balances.set(recipient, recipient_balance + amount);
-    }
-
-    // Approves a spender to transfer the caller’s public assets up to a specified amount.
+    // Approves a spender to transfer the caller's public assets up to a specified amount.
     // Increases the existing allowance if one is already set, otherwise creates a new allowance.
-    // The allowance is stored using a hash of the owner–spender pair as the key.
-    async transition approve_public(
+    // The allowance is stored using a hash of the owner-spender pair as the key.
+    fn approve_public(
         public spender: address,
         public amount: u128
-    ) -> Future {
+    ) -> Final {
         let allowance: TokenAllowance = TokenAllowance {
             account: self.caller,
             spender: spender
         };
         let allowance_key: field = BHP256::hash_to_field(allowance);
 
-        return finalize_approve_public(amount, allowance_key);
+        return final {
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
+
+            let current_allowance: u128 = allowances.get_or_use(allowance_key, 0u128);
+            // Increase or create the allowance amount
+            allowances.set(allowance_key, current_allowance + amount);
+        };
     }
 
-    async function finalize_approve_public(
-        amount: u128,
-        allowance_key: field
-    ) {
-
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
-
-        let current_allowance: u128 = allowances.get_or_use(allowance_key, 0u128);
-        // Increase or create the allowance amount
-        allowances.set(allowance_key, current_allowance + amount);
-    }
-
-    // Reduces a spender’s allowance to transfer the caller’s public assets by a specified amount.
-    // Decreases the existing allowance stored under the hash of the owner–spender pair.
+    // Reduces a spender's allowance to transfer the caller's public assets by a specified amount.
+    // Decreases the existing allowance stored under the hash of the owner-spender pair.
     // If the reduction exceeds the current allowance, the VM will catch the underflow.
-    async transition unapprove_public(
+    fn unapprove_public(
         public spender: address,
         public amount: u128
-    ) -> Future {
+    ) -> Final {
         let allowance: TokenAllowance = TokenAllowance {
             account: self.caller,
             spender: spender
         };
         let allowance_key: field = BHP256::hash_to_field(allowance);
 
-        return finalize_unapprove_public(amount, allowance_key);
-    }
-    async function finalize_unapprove_public(
-        amount: u128,
-        allowance_key: field
-    ) {
+        return final {
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
-
-        let current_allowance: u128 = allowances.get(allowance_key);
-        // Decrease the allowance amount
-        allowances.set(allowance_key, current_allowance - amount);
+            let current_allowance: u128 = allowances.get(allowance_key);
+            // Decrease the allowance amount
+            allowances.set(allowance_key, current_allowance - amount);
+        };
     }
 
     // Transfers public tokens from the owner to the recipient.
     // Can be called by any spender with sufficient allowance from the owner.
-    // Decreases the spender’s allowance by the transferred amount.
+    // Decreases the spender's allowance by the transferred amount.
     // Both sender and recipient must not be frozen in the freeze list.
-    async transition transfer_from_public(
+    fn transfer_from_public(
         public owner: address,
         public recipient: address,
         public amount: u128
-    ) -> Future {
+    ) -> Final {
         let allowance: TokenAllowance = TokenAllowance {
             account: owner,
             spender: self.caller,
         };
         let allowance_key: field = BHP256::hash_to_field(allowance);
 
-        return finalize_transfer_from_public(owner, recipient, amount, allowance_key);
-    }
+        return final {
+            let is_sender_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(owner, false);
+            assert_eq(is_sender_frozen, false);
+            let is_recipient_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(recipient, false);
+            assert_eq(is_recipient_frozen, false);
 
-    async function finalize_transfer_from_public(
-        sender: address,
-        recipient: address,
-        amount: u128,
-        allowance_key: field
-    ) {
-        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
-        assert_eq(is_sender_frozen, false);
-        let is_recipient_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(recipient, false);
-        assert_eq(is_recipient_frozen, false);
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
+            // Check that the spender is authorized to spend the amount
+            let current_allowance: u128 = allowances.get(allowance_key);
+            // Decrease the allowance by the amount being spent
+            allowances.set(allowance_key, current_allowance - amount);
 
-        // Check that the spender is authorized to spend the amount
-        let current_allowance: u128 = allowances.get(allowance_key);
-        // Decrease the allowance by the amount being spent
-        allowances.set(allowance_key, current_allowance - amount);
+            let sender_balance = balances.get(owner);
+            balances.set(owner, sender_balance - amount);
 
-        let sender_balance = balances.get(sender);
-        balances.set(sender, sender_balance - amount);
-
-        let recipient_balance = balances.get_or_use(recipient, 0u128);
-        balances.set(recipient, recipient_balance + amount);
+            let recipient_balance = balances.get_or_use(recipient, 0u128);
+            balances.set(recipient, recipient_balance + amount);
+        };
     }
 
     // Transfers public tokens from the caller to a recipient as a private token.
     // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
     // The sender must not be frozen in the freeze list.
-    async transition transfer_public_to_private(
+    fn transfer_public_to_private(
         recipient: address,
         public amount: u128,
-    ) -> (ComplianceRecord, Token, Future) {
+    ) -> (ComplianceRecord, Token, Final) {
         let token: Token = Token {
             owner: recipient,
             amount: amount
@@ -549,33 +555,29 @@ program lp_token.aleo {
             recipient: recipient,
         };
 
-        return (compliance_record, token, f_transfer_public_to_private(amount, self.caller));
-    }
+        let caller: address = self.caller;
+        return (compliance_record, token, final {
+            let is_sender_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(caller, false);
+            assert_eq(is_sender_frozen, false);
 
-    async function f_transfer_public_to_private(
-        amount: u128,
-        sender: address,
-    ) {
-        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
-        assert_eq(is_sender_frozen, false);
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
-
-        let sender_balance = balances.get(sender);
-        balances.set(sender, sender_balance - amount);
+            let sender_balance = balances.get(caller);
+            balances.set(caller, sender_balance - amount);
+        });
     }
 
     // Transfers public tokens from an owner to a recipient as a private token.
     // Can be called by any spender with sufficient allowance from the owner.
-    // Decreases the spender’s allowance by the transferred amount.
+    // Decreases the spender's allowance by the transferred amount.
     // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
     // The sender must not be frozen in the freeze list.
-    async transition transfer_from_public_to_private(
+    fn transfer_from_public_to_private(
         public owner: address,
         recipient: address,
         public amount: u128,
-    ) -> (ComplianceRecord, Token, Future) {
+    ) -> (ComplianceRecord, Token, Final) {
 
         let token: Token = Token {
             owner: recipient,
@@ -595,39 +597,33 @@ program lp_token.aleo {
             recipient: recipient,
         };
 
-        return (compliance_record, token, f_transfer_from_public_to_priv(owner, amount, allowance_key));
-    }
+        return (compliance_record, token, final {
+            let is_sender_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(owner, false);
+            assert_eq(is_sender_frozen, false);
 
-    async function f_transfer_from_public_to_priv(
-        sender: address,
-        amount: u128,
-        allowance_key: field,
-    ) {
-        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
-        assert_eq(is_sender_frozen, false);
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
+            // Check that the spender is authorized to spend the amount
+            let current_allowance: u128 = allowances.get(allowance_key);
+            // Decrease the allowance by the amount being spent
+            allowances.set(allowance_key, current_allowance - amount);
 
-        // Check that the spender is authorized to spend the amount
-        let current_allowance: u128 = allowances.get(allowance_key);
-        // Decrease the allowance by the amount being spent
-        allowances.set(allowance_key, current_allowance - amount);
-
-        let sender_balance = balances.get(sender);
-        balances.set(sender, sender_balance - amount);
+            let sender_balance = balances.get(owner);
+            balances.set(owner, sender_balance - amount);
+        });
     }
 
     // Transfers private tokens from the record owner to a recipient.
     // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
     // The sender must not be frozen in the freeze list.
     // The sender's privacy is preserved by proving non-inclusion in the freeze list Merkle tree.
-    async transition transfer_private(
+    fn transfer_private(
         recipient: address,
         amount: u128,
         input_record: Token,
         sender_merkle_proofs: [MerkleProof;2],
-    ) -> (ComplianceRecord, Token, Token, Future) {
+    ) -> (ComplianceRecord, Token, Token, Final) {
         let sender_root: field = verify_non_inclusion(input_record.owner, sender_merkle_proofs);
 
         let updated_record: Token = Token {
@@ -647,23 +643,20 @@ program lp_token.aleo {
             recipient: recipient,
         };
 
-        return (compliance_record, updated_record, transfer_record, f_transfer_private(sender_root));
-    }
+        return (compliance_record, updated_record, transfer_record, final {
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-    async function f_transfer_private(root: field) {
+            let current_root: field = sealance_freezelist_registry.aleo::freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+            let window: u32 = sealance_freezelist_registry.aleo::block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
-
-        let current_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
-        let window: u32 = sealance_freezelist_registry.aleo/block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
-
-        if (current_root != root) {
-            let previous_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
-            assert_eq(root, previous_root);
-            let updated_height: u32 = sealance_freezelist_registry.aleo/root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
-            assert(updated_height + window > block.height);
-        }
+            if (current_root != sender_root) {
+                let previous_root: field = sealance_freezelist_registry.aleo::freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+                assert_eq(sender_root, previous_root);
+                let updated_height: u32 = sealance_freezelist_registry.aleo::root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+                assert(updated_height + window > block.height);
+            }
+        });
     }
 
     // Transfers private tokens from the record owner to a recipient as a public tokens.
@@ -671,12 +664,12 @@ program lp_token.aleo {
     // A Credentials record is emitted for the sender
     // Both sender and recipient must not be frozen in the freeze list.
     // The sender's privacy is preserved by proving non-inclusion in the freeze list Merkle tree.
-    async transition transfer_private_to_public(
+    fn transfer_private_to_public(
         public recipient: address,
         public amount: u128,
         input_record: Token,
         sender_merkle_proofs: [MerkleProof; 2],
-    ) -> (ComplianceRecord, Token, Future) {
+    ) -> (ComplianceRecord, Token, Final) {
         let root: field = verify_non_inclusion(input_record.owner, sender_merkle_proofs);
 
         let updated_record: Token = Token {
@@ -694,54 +687,43 @@ program lp_token.aleo {
         return (
             compliance_record,
             updated_record,
-            f_transfer_private_to_public(
-                root,
-                recipient,
-                amount
-            )
+            final {
+                let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+                assert_eq(is_paused, false);
+
+                let current_root: field = sealance_freezelist_registry.aleo::freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+                let window: u32 = sealance_freezelist_registry.aleo::block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
+
+                if (current_root != root) {
+                    let previous_root: field = sealance_freezelist_registry.aleo::freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+                    assert_eq(root, previous_root);
+                    let updated_height: u32 = sealance_freezelist_registry.aleo::root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+                    assert(updated_height + window > block.height);
+                }
+
+                let is_recipient_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(recipient, false);
+                assert_eq(is_recipient_frozen, false);
+
+                let recipient_balance = balances.get_or_use(recipient, 0u128);
+                balances.set(recipient, recipient_balance + amount);
+            }
         );
-    }
-
-    async function f_transfer_private_to_public(
-        root: field,
-        recipient: address,
-        amount: u128    ) {
-        
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
-
-        let current_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
-        let window: u32 = sealance_freezelist_registry.aleo/block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
-
-        if (current_root != root) {
-            let previous_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
-            assert_eq(root, previous_root);
-            let updated_height: u32 = sealance_freezelist_registry.aleo/root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
-            assert(updated_height + window > block.height);
-        } 
-
-        let is_recipient_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(recipient, false);
-        assert_eq(is_recipient_frozen, false);
-
-        let recipient_balance = balances.get_or_use(recipient, 0u128);
-        balances.set(recipient, recipient_balance + amount);
     }
 
     // Stops or resumes all token transfers.
     // Can only be called by an address with the PAUSE_ROLE.
-    async transition set_pause_status(pause_status: bool) -> Future {
-        return f_set_pause_status(pause_status, self.caller);
+    fn set_pause_status(pause_status: bool) -> Final {
+        let caller: address = self.caller;
+        return final {
+            let role: u16 = address_to_role.get(caller);
+            assert(role & PAUSE_ROLE == PAUSE_ROLE);
+
+            pause.set(PAUSE_STATUS_INDEX, pause_status);
+        };
     }
 
-    async function f_set_pause_status(new_pause_status: bool, caller: address) {
-        let role: u16 = address_to_role.get(caller);
-        assert(role & PAUSE_ROLE == PAUSE_ROLE);
-        
-        pause.set(PAUSE_STATUS_INDEX, new_pause_status);
-    }
 
-
-    transition join(
+    fn join(
         private token_1: Token,
         private token_2: Token
     ) -> Token {
@@ -753,7 +735,7 @@ program lp_token.aleo {
         return new_token;
     }
 
-    transition split(
+    fn split(
         private token: Token,
         private amount: u128
     ) -> (Token, Token) {
@@ -773,12 +755,12 @@ program lp_token.aleo {
     // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
     // The sender must not be frozen in the freeze list.
     // The sender's privacy is preserved by using a Credentials record.
-    async transition transfer_private_with_creds(
+    fn transfer_private_with_creds(
         recipient: address,
         amount: u128,
         input_record: Token,
         credentials: Credentials,
-    ) -> (ComplianceRecord, Token, Token, Credentials, Future) {
+    ) -> (ComplianceRecord, Token, Token, Credentials, Final) {
         let updated_record: Token = Token {
             owner: input_record.owner,
             amount: input_record.amount - amount
@@ -801,89 +783,20 @@ program lp_token.aleo {
             freeze_list_root: credentials.freeze_list_root,
         };
 
-        return (compliance_record, updated_record, transfer_record, credentials_record, f_transfer_private_credentials(credentials.freeze_list_root));
-    }
+        let creds_root: field = credentials.freeze_list_root;
+        return (compliance_record, updated_record, transfer_record, credentials_record, final {
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-    async function f_transfer_private_credentials(root: field) {
+            let current_root: field = sealance_freezelist_registry.aleo::freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+            let window: u32 = sealance_freezelist_registry.aleo::block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
-
-        let current_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
-        let window: u32 = sealance_freezelist_registry.aleo/block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
-
-        if (current_root != root) {
-            let previous_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
-            assert_eq(root, previous_root);
-            let updated_height: u32 = sealance_freezelist_registry.aleo/root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
-            assert(updated_height + window > block.height);
-        }
-    }
-
-    // Calculates the hash of two sibling nodes in a Merkle tree.
-    // The order of the siblings depends on the index bit (0 = left, 1 = right).
-    // Uses Poseidon hash to compute the result.
-    inline calculate_hash_for_nodes(sibling1: field, sibling2: field, indexbit: u32) -> field {
-        let poseidon_params: [field; 3] = indexbit == 0u32 ? [0field, sibling1, sibling2] : [0field, sibling2, sibling1];
-        return Poseidon4::hash_to_field(poseidon_params);
-    }
-
-    inline calculate_hash_for_leaves(sibling1: field, sibling2: field, indexbit: u32) -> field {
-        let poseidon_params: [field; 3] = indexbit == 0u32 ? [1field, sibling1, sibling2] : [1field, sibling2, sibling1];
-        return Poseidon4::hash_to_field(poseidon_params);
-    }
-
-    // Calculates the Merkle root and the depth of a Merkle proof path.
-    // Iteratively hashes the sibling path based on the leaf index to reconstruct the root.
-    // Stops when a zero field is encountered in the siblings array, indicating the end of the valid path.
-    // Returns the calculated root and the actual depth reached.
-    inline calculate_root_depth_siblings(merkle_proof: MerkleProof) -> (public field, public u32) {
-        let root: field = calculate_hash_for_leaves(merkle_proof.siblings[0u8], merkle_proof.siblings[1u8],  merkle_proof.leaf_index % 2u32);
-        for i: u32 in 2u32..MAX_TREE_DEPTH + 1u32 {
-            if (merkle_proof.siblings[i] == 0field) {
-                return (root, i - 1u32);
+            if (current_root != creds_root) {
+                let previous_root: field = sealance_freezelist_registry.aleo::freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+                assert_eq(creds_root, previous_root);
+                let updated_height: u32 = sealance_freezelist_registry.aleo::root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+                assert(updated_height + window > block.height);
             }
-            root = calculate_hash_for_nodes(root, merkle_proof.siblings[i], (merkle_proof.leaf_index / (2u32**(i-1u32))) % 2u32);
-        }
-        return (root, MAX_TREE_DEPTH);
-    }
-
-    // Verifies non-inclusion of an address in a Merkle tree sorted in ascending order by address (as field).
-    // Accepts two Merkle proofs representing the neighboring leaves around the missing address.
-    // Returns the common Merkle root if the address is proven to be outside the tree.
-    // If the tree is not sorted correctly, this function may return incorrect results.
-    inline verify_non_inclusion(addr: address, merkle_proofs: [MerkleProof;2]) -> field {
-        let (root1, depth1): (field, u32)= calculate_root_depth_siblings(merkle_proofs[0u32]);
-        let (root2, depth2): (field, u32) = calculate_root_depth_siblings(merkle_proofs[1u32]);
-
-        // Ensure the roots from the merkle proofs are the same
-        assert_eq(root1, root2);
-        // Ensure the depth of the merkle proofs is the same
-        assert_eq(depth1, depth2);
-        
-        let addr_field: field = addr as field;
-        if (merkle_proofs[0u32].leaf_index == merkle_proofs[1u32].leaf_index) {
-            // Ensure that if the address is the most left leaf, it is less than the first sibling
-            if (merkle_proofs[0u32].leaf_index == 0u32) {
-                assert(addr_field < merkle_proofs[0u32].siblings[0u32]);
-            } else {
-                // Ensure that if the address is the most right leaf
-                let last_index_leaf: u32 = 2u32 ** depth1 - 1u32;
-                assert_eq(merkle_proofs[0u32].leaf_index, last_index_leaf);
-                // Ensure that the address is bigger than the first sibling
-                assert(addr_field > merkle_proofs[0u32].siblings[0u32]);
-            }
-        } else {
-            // Ensure the address is in between the provided leaves
-            assert(addr_field > merkle_proofs[0u32].siblings[0u32]);
-            assert(addr_field < merkle_proofs[1u32].siblings[0u32]);
-            // Ensure that the leaf indexes are not greater than the last possible leaf index
-            let last_index_leaf: u32 = 2u32 ** depth1 - 1u32;
-            assert(merkle_proofs[1u32].leaf_index <= last_index_leaf);
-            // Ensure the leaves are adjacent
-            assert_eq(merkle_proofs[0u32].leaf_index + 1u32, merkle_proofs[1u32].leaf_index);
-        }
-        
-        return root1;
+        });
     }
 }

--- a/programs/amm/stable_token_1.leo
+++ b/programs/amm/stable_token_1.leo
@@ -1,0 +1,889 @@
+import sealance_freezelist_registry.aleo;
+import multisig_core.aleo;
+
+program stable_token_1.aleo {
+    @custom
+    async constructor() {
+        // Only require multisig for upgrades - initial deployment has no checks.
+        if self.edition > 0u16 {
+            let signing_op_id = BHP256::hash_to_field(ChecksumEdition { checksum: self.checksum, edition: self.edition });
+
+            let wallet_signing_op_id_hash = BHP256::hash_to_field(multisig_core.aleo/WalletSigningOpId { wallet_id: self.address, signing_op_id: signing_op_id });
+            let signing_complete = multisig_core.aleo/completed_signing_ops.contains(wallet_signing_op_id_hash);
+            assert(signing_complete);
+        }
+    }
+
+    // A helper for calculating a signing_op_id from the program's checksum and edition.
+    // By deriving the signing_op_id from both we ensure that downgrades cannot take place.
+    transition get_signing_op_id_for_deploy(checksum: [u8; 32], edition: u16) -> field {
+        return BHP256::hash_to_field(ChecksumEdition { checksum: checksum, edition: edition });
+    }
+
+    record Token {
+        owner: address,
+        amount: u128
+    }
+
+    // Compliance record used for the investigator
+    record ComplianceRecord {
+        owner: address,
+        amount: u128,
+        sender: address,
+        recipient: address
+    }
+
+    record Credentials {
+        owner: address,
+        freeze_list_root: field,
+    }
+
+    struct MerkleProof {
+        siblings: [field; 16],
+        leaf_index: u32
+    }
+
+    struct ChecksumEdition {
+        checksum: [u8; 32],
+        edition: u16,
+    }
+
+    struct TokenInfo {
+        name: u128, // ASCII text represented in bits, and the u128 value of the bitstring
+        symbol: u128, // ASCII text represented in bits, and the u128 value of the bitstring
+        decimals: u8,
+        supply: u128,
+        max_supply: u128,
+    }
+
+    struct TokenAllowance {
+        account: address,
+        spender: address,
+    }
+    
+    const TOKEN_INFO_INDEX: bool = true;
+    // token specs
+    mapping token_info: bool => TokenInfo;
+
+    mapping balances: address => u128;
+    mapping allowances: field => u128; // hash(account, spender) => TokenAllowance
+
+    // Roles can be assigned using bitmasking to allow multiple roles per address
+    const NONE_ROLE: u16 = 0u16;
+    const MINTER_ROLE: u16 = 1u16;
+    const BURNER_ROLE: u16 = 2u16;
+    const PAUSE_ROLE: u16 = 4u16;   // can pause/unpause transfers
+    const MANAGER_ROLE: u16 = 8u16; // can only assign roles
+    mapping address_to_role: address => u16;
+
+    // Only this address can deploy and initialize the program
+    const DEPLOYER_ADDRESS: address = aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px;
+
+    // This address receives compliance records (can be updated with the contract upgrade)
+    const INVESTIGATOR_ADDRESS: address = aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px;
+
+    const PAUSE_STATUS_INDEX: bool = true;
+    mapping pause: bool => bool;
+
+    const ZERO_ADDRESS: address = aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc; // ZERO_ADDRESS as field equals to 0field
+    const CURRENT_FREEZE_LIST_ROOT_INDEX: u8 = 1u8;
+    const PREVIOUS_FREEZE_LIST_ROOT_INDEX: u8 = 2u8;
+    const BLOCK_HEIGHT_WINDOW_INDEX: bool = true;
+    const ROOT_UPDATED_HEIGHT_INDEX: bool = true;
+    // Maximum depth of the Merkle tree used in freeze list proofs.
+    // The siblings array has MAX_TREE_DEPTH + 1 elements because siblings[0] holds the leaf itself.
+    const MAX_TREE_DEPTH: u32 = 15u32;
+
+    // -------------------------
+    // Called by token admins
+    // -------------------------
+
+
+    // Updates the address assigned to a given role.
+    // Can only be called by the current role manager.
+    async transition update_role(public new_address: address, role: u16) -> Future {
+        return f_update_role(new_address, self.caller, role);
+    }
+    async function f_update_role(new_address: address, caller: address, new_role: u16) {
+        let current_role: u16 = address_to_role.get(caller);
+        assert(current_role & MANAGER_ROLE == MANAGER_ROLE);
+        
+        if (caller == new_address) { 
+            assert(new_role & MANAGER_ROLE == MANAGER_ROLE); 
+        }
+
+        address_to_role.set(new_address, new_role);
+
+    }
+
+    // Initializes the freeze list, token specifications, the admin and the investigator.
+    // Can be called only once and only by the INITIAL_ADMIN    
+    // Sets the token metadata (name, symbol, decimals, max supply).
+    // Sets the block height window, the initial empty Merkle root,
+    // and initialize the freeze_list_last_index, freeze_list, and freeze_list_index with a ZERO_ADDRESS placeholder.
+    async transition initialize(
+        public name: u128,
+        public symbol: u128,
+        public decimals: u8,
+        public max_supply: u128,
+        public admin: address,
+    ) -> Future {
+        return finalize_initialize(
+            name,
+            symbol,
+            decimals,
+            max_supply,
+            admin,
+            self.caller,
+        );
+    }
+    async function finalize_initialize(
+        name: u128,
+        symbol: u128,
+        decimals: u8,
+        max_supply: u128,
+        admin: address, 
+        caller: address,
+    ) {
+        // Check if the token has already been initialized
+        let already_initialized: bool = token_info.contains(TOKEN_INFO_INDEX);
+        assert_eq(already_initialized, false);
+        
+        // Only the INITIAL_CONFIGURATION_ADDRESS can initialize the contract
+        assert_eq(caller, DEPLOYER_ADDRESS);
+        
+        address_to_role.set(admin, MANAGER_ROLE);
+
+        let token: TokenInfo = TokenInfo {
+            name: name,
+            symbol: symbol,
+            decimals: decimals,
+            supply: 0u128, // placeholder value; not used
+            max_supply: max_supply
+        };
+
+        token_info.set(TOKEN_INFO_INDEX, token);
+
+        pause.set(PAUSE_STATUS_INDEX, false);
+    }
+
+    // Generates a Credential record for the signer.
+    // Allows future private transfers without needing to re-prove non-inclusion in the freeze list.
+    // The signer's privacy is preserved by proving non-inclusion in the freeze list Merkle tree.
+    async transition get_credentials(sender_merkle_proofs: [MerkleProof;2]) -> (Credentials, Future) {
+        let root: field = verify_non_inclusion(self.signer, sender_merkle_proofs);
+
+        let credentials_record: Credentials = Credentials {
+            owner: self.signer,
+            freeze_list_root: root,
+        };
+
+        return (credentials_record, f_get_credentials(root));
+    }
+    async function f_get_credentials(root: field) {
+        let current_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+        let window: u32 = sealance_freezelist_registry.aleo/block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
+
+        if (current_root != root) {
+            let previous_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+            assert_eq(root, previous_root);
+            let updated_height: u32 = sealance_freezelist_registry.aleo/root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+            assert(updated_height + window > block.height);
+        }
+    }
+
+    // Mints new public tokens to the specified recipient’s balance.
+    // Can only be called by a minter.
+    // Ensures that the new total supply does not exceed the maximum supply.
+    // Updates the recipient’s balance and the total token supply in the token metadata.
+    async transition mint_public(
+        public recipient: address,
+        public amount: u128,
+    ) -> Future {
+        return finalize_mint_public(recipient, amount, self.caller);
+    }
+    async function finalize_mint_public(
+        recipient: address,
+        amount: u128,
+        caller: address
+    ) {
+
+        let role: u16 = address_to_role.get(caller);
+        assert(role & MINTER_ROLE == MINTER_ROLE);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let token = token_info.get(TOKEN_INFO_INDEX);
+        // Check that the token supply + amount <= max_supply
+        let new_supply: u128 = token.supply + amount;
+        assert(new_supply <= token.max_supply);
+
+        // Update the balance
+        let balance = balances.get_or_use(recipient, 0u128);
+        let new_balance = amount + balance;
+        balances.set(recipient, new_balance);
+
+        // Update the token supply
+        let new_metadata: TokenInfo = TokenInfo {
+            name: token.name,
+            symbol: token.symbol,
+            decimals: token.decimals,
+            supply: new_supply,
+            max_supply: token.max_supply,
+        };
+        token_info.set(TOKEN_INFO_INDEX, new_metadata);
+    }
+
+    // Mints new private tokens to the specified recipient.
+    // Can only be called by a minter.
+    // Ensures that the new total supply does not exceed the maximum supply.
+    // Updates the total token supply in the token metadata.
+    async transition mint_private(
+        recipient: address,
+        public amount: u128,
+        ) -> (ComplianceRecord, Token, Future) {
+        let token: Token = Token {
+            owner: recipient,
+            amount: amount,
+        };
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: INVESTIGATOR_ADDRESS,
+            amount: amount,
+            sender: ZERO_ADDRESS,
+            recipient: recipient,
+        };
+        
+        return (compliance_record, token, finalize_mint_private(amount, self.caller));
+    }
+
+    async function finalize_mint_private(
+        amount: u128,
+        caller: address,
+    ) {
+        let role: u16 = address_to_role.get(caller);
+        assert(role & MINTER_ROLE == MINTER_ROLE);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let token = token_info.get(TOKEN_INFO_INDEX);
+
+        // Check that the token supply + amount <= max_supply
+        let new_supply: u128 = token.supply + amount;
+        assert(new_supply <= token.max_supply);
+
+        // Update the token supply
+        let new_metadata: TokenInfo = TokenInfo {
+            name: token.name,
+            symbol: token.symbol,
+            decimals: token.decimals,
+            supply: new_supply,
+            max_supply: token.max_supply,
+        };
+        token_info.set(TOKEN_INFO_INDEX, new_metadata);
+    }
+
+    // Burns public tokens from the specified owner’s balance.
+    // Can only be called by a burner.
+    // Decreases the owner’s balance and reduces the total token supply in the token metadata.
+    async transition burn_public(
+        public owner: address,
+        public amount: u128
+    ) -> Future {
+        return finalize_burn_public(owner, amount, self.caller);
+    }
+
+    async function finalize_burn_public(
+        owner: address,
+        amount: u128,
+        caller: address,
+    ) {
+        let role: u16 = address_to_role.get(caller);
+        assert(role & BURNER_ROLE == BURNER_ROLE);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        // Update the balance
+        let balance = balances.get(owner);
+        let new_balance = balance - amount;
+        balances.set(owner, new_balance);
+
+        let token = token_info.get(TOKEN_INFO_INDEX);
+
+        let new_metadata: TokenInfo = TokenInfo {
+            name: token.name,
+            symbol: token.symbol,
+            decimals: token.decimals,
+            supply: token.supply - amount, // underflow will be caught by the VM
+            max_supply: token.max_supply,
+        };
+        token_info.set(TOKEN_INFO_INDEX, new_metadata);
+    }
+
+    // Burns tokens from a private record (non-public asset).
+    // Can only be called by a burner.
+    // Reduces the amount in the provided private record and decreases the total token supply in the token metadata.
+    async transition burn_private(
+        input_record: Token,
+        public amount: u128
+    ) -> (ComplianceRecord, Token, Future) {
+        let output_record: Token = Token {
+            owner: input_record.owner,
+            amount: input_record.amount - amount
+        };
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: INVESTIGATOR_ADDRESS,
+            amount: amount,
+            sender: input_record.owner,
+            recipient: ZERO_ADDRESS,
+        };
+
+        return (compliance_record, output_record, finalize_burn_private(amount, self.caller));
+    }
+    async function finalize_burn_private(
+        amount: u128,
+        caller: address,
+    ) {
+        let role: u16 = address_to_role.get(caller);
+        assert(role & BURNER_ROLE == BURNER_ROLE);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let token = token_info.get(TOKEN_INFO_INDEX);
+
+        // Update the token supply
+        let new_metadata: TokenInfo = TokenInfo {
+            name: token.name,
+            symbol: token.symbol,
+            decimals: token.decimals,
+            supply: token.supply - amount, // underflow will be caught by the VM
+            max_supply: token.max_supply,
+        };
+        token_info.set(TOKEN_INFO_INDEX, new_metadata);
+    }
+
+    // -------------------------
+    // Called by token owners/DeFi contracts
+    // -------------------------
+
+    // Transfers public tokens from the caller to the recipient.
+    // Both sender and recipient must not be frozen in the freeze list.
+    async transition transfer_public(
+        public recipient: address,
+        public amount: u128
+    ) -> Future {
+        return finalize_transfer_public(recipient, amount, self.caller);
+    }
+
+    async function finalize_transfer_public(
+        recipient: address,
+        amount: u128,
+        sender: address
+    ) {
+        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
+        assert_eq(is_sender_frozen, false);
+        let is_recipient_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(recipient, false);
+        assert_eq(is_recipient_frozen, false);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let sender_balance = balances.get(sender);
+        balances.set(sender, sender_balance - amount);
+
+        let recipient_balance = balances.get_or_use(recipient, 0u128);
+        balances.set(recipient, recipient_balance + amount);
+    }
+
+    // Transfers public tokens from the signer to the recipient.
+    // Both sender and recipient must not be frozen in the freeze list.
+    async transition transfer_public_as_signer(
+        public recipient: address,
+        public amount: u128
+    ) -> Future {
+        return f_transfer_public_as_signer(recipient, amount, self.signer);
+    }
+
+    async function f_transfer_public_as_signer(
+        recipient: address,
+        amount: u128,
+        sender: address
+    ) {
+        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
+        assert_eq(is_sender_frozen, false);
+        let is_recipient_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(recipient, false);
+        assert_eq(is_recipient_frozen, false);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let sender_balance = balances.get(sender);
+        balances.set(sender, sender_balance - amount);
+
+        let recipient_balance = balances.get_or_use(recipient, 0u128);
+        balances.set(recipient, recipient_balance + amount);
+    }
+
+    // Approves a spender to transfer the caller’s public assets up to a specified amount.
+    // Increases the existing allowance if one is already set, otherwise creates a new allowance.
+    // The allowance is stored using a hash of the owner–spender pair as the key.
+    async transition approve_public(
+        public spender: address,
+        public amount: u128
+    ) -> Future {
+        let allowance: TokenAllowance = TokenAllowance {
+            account: self.caller,
+            spender: spender
+        };
+        let allowance_key: field = BHP256::hash_to_field(allowance);
+
+        return finalize_approve_public(amount, allowance_key);
+    }
+
+    async function finalize_approve_public(
+        amount: u128,
+        allowance_key: field
+    ) {
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let current_allowance: u128 = allowances.get_or_use(allowance_key, 0u128);
+        // Increase or create the allowance amount
+        allowances.set(allowance_key, current_allowance + amount);
+    }
+
+    // Reduces a spender’s allowance to transfer the caller’s public assets by a specified amount.
+    // Decreases the existing allowance stored under the hash of the owner–spender pair.
+    // If the reduction exceeds the current allowance, the VM will catch the underflow.
+    async transition unapprove_public(
+        public spender: address,
+        public amount: u128
+    ) -> Future {
+        let allowance: TokenAllowance = TokenAllowance {
+            account: self.caller,
+            spender: spender
+        };
+        let allowance_key: field = BHP256::hash_to_field(allowance);
+
+        return finalize_unapprove_public(amount, allowance_key);
+    }
+    async function finalize_unapprove_public(
+        amount: u128,
+        allowance_key: field
+    ) {
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let current_allowance: u128 = allowances.get(allowance_key);
+        // Decrease the allowance amount
+        allowances.set(allowance_key, current_allowance - amount);
+    }
+
+    // Transfers public tokens from the owner to the recipient.
+    // Can be called by any spender with sufficient allowance from the owner.
+    // Decreases the spender’s allowance by the transferred amount.
+    // Both sender and recipient must not be frozen in the freeze list.
+    async transition transfer_from_public(
+        public owner: address,
+        public recipient: address,
+        public amount: u128
+    ) -> Future {
+        let allowance: TokenAllowance = TokenAllowance {
+            account: owner,
+            spender: self.caller,
+        };
+        let allowance_key: field = BHP256::hash_to_field(allowance);
+
+        return finalize_transfer_from_public(owner, recipient, amount, allowance_key);
+    }
+
+    async function finalize_transfer_from_public(
+        sender: address,
+        recipient: address,
+        amount: u128,
+        allowance_key: field
+    ) {
+        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
+        assert_eq(is_sender_frozen, false);
+        let is_recipient_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(recipient, false);
+        assert_eq(is_recipient_frozen, false);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        // Check that the spender is authorized to spend the amount
+        let current_allowance: u128 = allowances.get(allowance_key);
+        // Decrease the allowance by the amount being spent
+        allowances.set(allowance_key, current_allowance - amount);
+
+        let sender_balance = balances.get(sender);
+        balances.set(sender, sender_balance - amount);
+
+        let recipient_balance = balances.get_or_use(recipient, 0u128);
+        balances.set(recipient, recipient_balance + amount);
+    }
+
+    // Transfers public tokens from the caller to a recipient as a private token.
+    // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
+    // The sender must not be frozen in the freeze list.
+    async transition transfer_public_to_private(
+        recipient: address,
+        public amount: u128,
+    ) -> (ComplianceRecord, Token, Future) {
+        let token: Token = Token {
+            owner: recipient,
+            amount: amount
+        };
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: INVESTIGATOR_ADDRESS,
+            amount: amount,
+            sender: self.caller,
+            recipient: recipient,
+        };
+
+        return (compliance_record, token, f_transfer_public_to_private(amount, self.caller));
+    }
+
+    async function f_transfer_public_to_private(
+        amount: u128,
+        sender: address,
+    ) {
+        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
+        assert_eq(is_sender_frozen, false);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let sender_balance = balances.get(sender);
+        balances.set(sender, sender_balance - amount);
+    }
+
+    // Transfers public tokens from an owner to a recipient as a private token.
+    // Can be called by any spender with sufficient allowance from the owner.
+    // Decreases the spender’s allowance by the transferred amount.
+    // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
+    // The sender must not be frozen in the freeze list.
+    async transition transfer_from_public_to_private(
+        public owner: address,
+        recipient: address,
+        public amount: u128,
+    ) -> (ComplianceRecord, Token, Future) {
+
+        let token: Token = Token {
+            owner: recipient,
+            amount: amount
+        };
+
+        let allowance: TokenAllowance = TokenAllowance {
+            account: owner,
+            spender: self.caller,
+        };
+        let allowance_key: field = BHP256::hash_to_field(allowance);
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: INVESTIGATOR_ADDRESS,
+            amount: amount,
+            sender: owner,
+            recipient: recipient,
+        };
+
+        return (compliance_record, token, f_transfer_from_public_to_priv(owner, amount, allowance_key));
+    }
+
+    async function f_transfer_from_public_to_priv(
+        sender: address,
+        amount: u128,
+        allowance_key: field,
+    ) {
+        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
+        assert_eq(is_sender_frozen, false);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        // Check that the spender is authorized to spend the amount
+        let current_allowance: u128 = allowances.get(allowance_key);
+        // Decrease the allowance by the amount being spent
+        allowances.set(allowance_key, current_allowance - amount);
+
+        let sender_balance = balances.get(sender);
+        balances.set(sender, sender_balance - amount);
+    }
+
+    // Transfers private tokens from the record owner to a recipient.
+    // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
+    // The sender must not be frozen in the freeze list.
+    // The sender's privacy is preserved by proving non-inclusion in the freeze list Merkle tree.
+    async transition transfer_private(
+        recipient: address,
+        amount: u128,
+        input_record: Token,
+        sender_merkle_proofs: [MerkleProof;2],
+    ) -> (ComplianceRecord, Token, Token, Future) {
+        let sender_root: field = verify_non_inclusion(input_record.owner, sender_merkle_proofs);
+
+        let updated_record: Token = Token {
+            owner: input_record.owner,
+            amount: input_record.amount - amount
+        };
+
+        let transfer_record: Token = Token {
+            owner: recipient,
+            amount: amount
+        };
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: INVESTIGATOR_ADDRESS,
+            amount: amount,
+            sender: input_record.owner,
+            recipient: recipient,
+        };
+
+        return (compliance_record, updated_record, transfer_record, f_transfer_private(sender_root));
+    }
+
+    async function f_transfer_private(root: field) {
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let current_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+        let window: u32 = sealance_freezelist_registry.aleo/block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
+
+        if (current_root != root) {
+            let previous_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+            assert_eq(root, previous_root);
+            let updated_height: u32 = sealance_freezelist_registry.aleo/root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+            assert(updated_height + window > block.height);
+        }
+    }
+
+    // Transfers private tokens from the record owner to a recipient as a public tokens.
+    // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
+    // A Credentials record is emitted for the sender
+    // Both sender and recipient must not be frozen in the freeze list.
+    // The sender's privacy is preserved by proving non-inclusion in the freeze list Merkle tree.
+    async transition transfer_private_to_public(
+        public recipient: address,
+        public amount: u128,
+        input_record: Token,
+        sender_merkle_proofs: [MerkleProof; 2],
+    ) -> (ComplianceRecord, Token, Future) {
+        let root: field = verify_non_inclusion(input_record.owner, sender_merkle_proofs);
+
+        let updated_record: Token = Token {
+            owner: input_record.owner,
+            amount: input_record.amount - amount
+        };
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: INVESTIGATOR_ADDRESS,
+            amount: amount,
+            sender: input_record.owner,
+            recipient: recipient,
+        };
+
+        return (
+            compliance_record,
+            updated_record,
+            f_transfer_private_to_public(
+                root,
+                recipient,
+                amount
+            )
+        );
+    }
+
+    async function f_transfer_private_to_public(
+        root: field,
+        recipient: address,
+        amount: u128    ) {
+        
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let current_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+        let window: u32 = sealance_freezelist_registry.aleo/block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
+
+        if (current_root != root) {
+            let previous_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+            assert_eq(root, previous_root);
+            let updated_height: u32 = sealance_freezelist_registry.aleo/root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+            assert(updated_height + window > block.height);
+        } 
+
+        let is_recipient_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(recipient, false);
+        assert_eq(is_recipient_frozen, false);
+
+        let recipient_balance = balances.get_or_use(recipient, 0u128);
+        balances.set(recipient, recipient_balance + amount);
+    }
+
+    // Stops or resumes all token transfers.
+    // Can only be called by an address with the PAUSE_ROLE.
+    async transition set_pause_status(pause_status: bool) -> Future {
+        return f_set_pause_status(pause_status, self.caller);
+    }
+
+    async function f_set_pause_status(new_pause_status: bool, caller: address) {
+        let role: u16 = address_to_role.get(caller);
+        assert(role & PAUSE_ROLE == PAUSE_ROLE);
+        
+        pause.set(PAUSE_STATUS_INDEX, new_pause_status);
+    }
+
+
+    transition join(
+        private token_1: Token,
+        private token_2: Token
+    ) -> Token {
+        let new_token: Token = Token {
+            owner: token_1.owner,
+            amount: token_1.amount + token_2.amount
+        };
+
+        return new_token;
+    }
+
+    transition split(
+        private token: Token,
+        private amount: u128
+    ) -> (Token, Token) {
+        let new_token_1: Token = Token {
+            owner: token.owner,
+            amount: amount
+        };
+        let new_token_2: Token = Token {
+            owner: token.owner,
+            amount: token.amount - amount
+        };
+
+        return (new_token_1, new_token_2);
+    }
+
+    // Transfers private tokens from the record owner to a recipient.
+    // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
+    // The sender must not be frozen in the freeze list.
+    // The sender's privacy is preserved by using a Credentials record.
+    async transition transfer_private_with_creds(
+        recipient: address,
+        amount: u128,
+        input_record: Token,
+        credentials: Credentials,
+    ) -> (ComplianceRecord, Token, Token, Credentials, Future) {
+        let updated_record: Token = Token {
+            owner: input_record.owner,
+            amount: input_record.amount - amount
+        };
+
+        let transfer_record: Token = Token {
+            owner: recipient,
+            amount: amount
+        };
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: INVESTIGATOR_ADDRESS,
+            amount: amount,
+            sender: input_record.owner,
+            recipient: recipient,
+        };
+
+        let credentials_record: Credentials = Credentials {
+            owner: credentials.owner,
+            freeze_list_root: credentials.freeze_list_root,
+        };
+
+        return (compliance_record, updated_record, transfer_record, credentials_record, f_transfer_private_credentials(credentials.freeze_list_root));
+    }
+
+    async function f_transfer_private_credentials(root: field) {
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let current_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+        let window: u32 = sealance_freezelist_registry.aleo/block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
+
+        if (current_root != root) {
+            let previous_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+            assert_eq(root, previous_root);
+            let updated_height: u32 = sealance_freezelist_registry.aleo/root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+            assert(updated_height + window > block.height);
+        }
+    }
+
+    // Calculates the hash of two sibling nodes in a Merkle tree.
+    // The order of the siblings depends on the index bit (0 = left, 1 = right).
+    // Uses Poseidon hash to compute the result.
+    inline calculate_hash_for_nodes(sibling1: field, sibling2: field, indexbit: u32) -> field {
+        let poseidon_params: [field; 3] = indexbit == 0u32 ? [0field, sibling1, sibling2] : [0field, sibling2, sibling1];
+        return Poseidon4::hash_to_field(poseidon_params);
+    }
+
+    inline calculate_hash_for_leaves(sibling1: field, sibling2: field, indexbit: u32) -> field {
+        let poseidon_params: [field; 3] = indexbit == 0u32 ? [1field, sibling1, sibling2] : [1field, sibling2, sibling1];
+        return Poseidon4::hash_to_field(poseidon_params);
+    }
+
+    // Calculates the Merkle root and the depth of a Merkle proof path.
+    // Iteratively hashes the sibling path based on the leaf index to reconstruct the root.
+    // Stops when a zero field is encountered in the siblings array, indicating the end of the valid path.
+    // Returns the calculated root and the actual depth reached.
+    inline calculate_root_depth_siblings(merkle_proof: MerkleProof) -> (public field, public u32) {
+        let root: field = calculate_hash_for_leaves(merkle_proof.siblings[0u8], merkle_proof.siblings[1u8],  merkle_proof.leaf_index % 2u32);
+        for i: u32 in 2u32..MAX_TREE_DEPTH + 1u32 {
+            if (merkle_proof.siblings[i] == 0field) {
+                return (root, i - 1u32);
+            }
+            root = calculate_hash_for_nodes(root, merkle_proof.siblings[i], (merkle_proof.leaf_index / (2u32**(i-1u32))) % 2u32);
+        }
+        return (root, MAX_TREE_DEPTH);
+    }
+
+    // Verifies non-inclusion of an address in a Merkle tree sorted in ascending order by address (as field).
+    // Accepts two Merkle proofs representing the neighboring leaves around the missing address.
+    // Returns the common Merkle root if the address is proven to be outside the tree.
+    // If the tree is not sorted correctly, this function may return incorrect results.
+    inline verify_non_inclusion(addr: address, merkle_proofs: [MerkleProof;2]) -> field {
+        let (root1, depth1): (field, u32)= calculate_root_depth_siblings(merkle_proofs[0u32]);
+        let (root2, depth2): (field, u32) = calculate_root_depth_siblings(merkle_proofs[1u32]);
+
+        // Ensure the roots from the merkle proofs are the same
+        assert_eq(root1, root2);
+        // Ensure the depth of the merkle proofs is the same
+        assert_eq(depth1, depth2);
+        
+        let addr_field: field = addr as field;
+        if (merkle_proofs[0u32].leaf_index == merkle_proofs[1u32].leaf_index) {
+            // Ensure that if the address is the most left leaf, it is less than the first sibling
+            if (merkle_proofs[0u32].leaf_index == 0u32) {
+                assert(addr_field < merkle_proofs[0u32].siblings[0u32]);
+            } else {
+                // Ensure that if the address is the most right leaf
+                let last_index_leaf: u32 = 2u32 ** depth1 - 1u32;
+                assert_eq(merkle_proofs[0u32].leaf_index, last_index_leaf);
+                // Ensure that the address is bigger than the first sibling
+                assert(addr_field > merkle_proofs[0u32].siblings[0u32]);
+            }
+        } else {
+            // Ensure the address is in between the provided leaves
+            assert(addr_field > merkle_proofs[0u32].siblings[0u32]);
+            assert(addr_field < merkle_proofs[1u32].siblings[0u32]);
+            // Ensure that the leaf indexes are not greater than the last possible leaf index
+            let last_index_leaf: u32 = 2u32 ** depth1 - 1u32;
+            assert(merkle_proofs[1u32].leaf_index <= last_index_leaf);
+            // Ensure the leaves are adjacent
+            assert_eq(merkle_proofs[0u32].leaf_index + 1u32, merkle_proofs[1u32].leaf_index);
+        }
+        
+        return root1;
+    }
+}

--- a/programs/amm/stable_token_1.leo
+++ b/programs/amm/stable_token_1.leo
@@ -1,22 +1,112 @@
 import sealance_freezelist_registry.aleo;
 import multisig_core.aleo;
 
+struct MerkleProof {
+    siblings: [field; 16],
+    leaf_index: u32
+}
+
+struct ChecksumEdition {
+    checksum: [u8; 32],
+    edition: u16,
+}
+
+struct TokenInfo {
+    name: u128, // ASCII text represented in bits, and the u128 value of the bitstring
+    symbol: u128, // ASCII text represented in bits, and the u128 value of the bitstring
+    decimals: u8,
+    supply: u128,
+    max_supply: u128,
+}
+
+struct TokenAllowance {
+    account: address,
+    spender: address,
+}
+
+// Calculates the hash of two sibling nodes in a Merkle tree.
+// The order of the siblings depends on the index bit (0 = left, 1 = right).
+// Uses Poseidon hash to compute the result.
+fn calculate_hash_for_nodes(sibling1: field, sibling2: field, indexbit: u32) -> field {
+    let poseidon_params: [field; 3] = indexbit == 0u32 ? [0field, sibling1, sibling2] : [0field, sibling2, sibling1];
+    return Poseidon4::hash_to_field(poseidon_params);
+}
+
+fn calculate_hash_for_leaves(sibling1: field, sibling2: field, indexbit: u32) -> field {
+    let poseidon_params: [field; 3] = indexbit == 0u32 ? [1field, sibling1, sibling2] : [1field, sibling2, sibling1];
+    return Poseidon4::hash_to_field(poseidon_params);
+}
+
+// Calculates the Merkle root and the depth of a Merkle proof path.
+// Iteratively hashes the sibling path based on the leaf index to reconstruct the root.
+// Stops when a zero field is encountered in the siblings array, indicating the end of the valid path.
+// Returns the calculated root and the actual depth reached.
+fn calculate_root_depth_siblings(merkle_proof: MerkleProof) -> (public field, public u32) {
+    let root: field = calculate_hash_for_leaves(merkle_proof.siblings[0u8], merkle_proof.siblings[1u8],  merkle_proof.leaf_index % 2u32);
+    for i: u32 in 2u32..MAX_TREE_DEPTH + 1u32 {
+        if (merkle_proof.siblings[i] == 0field) {
+            return (root, i - 1u32);
+        }
+        root = calculate_hash_for_nodes(root, merkle_proof.siblings[i], (merkle_proof.leaf_index / (2u32**(i-1u32))) % 2u32);
+    }
+    return (root, MAX_TREE_DEPTH);
+}
+
+// Verifies non-inclusion of an address in a Merkle tree sorted in ascending order by address (as field).
+// Accepts two Merkle proofs representing the neighboring leaves around the missing address.
+// Returns the common Merkle root if the address is proven to be outside the tree.
+// If the tree is not sorted correctly, this function may return incorrect results.
+fn verify_non_inclusion(addr: address, merkle_proofs: [MerkleProof;2]) -> field {
+    let (root1, depth1): (field, u32)= calculate_root_depth_siblings(merkle_proofs[0u32]);
+    let (root2, depth2): (field, u32) = calculate_root_depth_siblings(merkle_proofs[1u32]);
+
+    // Ensure the roots from the merkle proofs are the same
+    assert_eq(root1, root2);
+    // Ensure the depth of the merkle proofs is the same
+    assert_eq(depth1, depth2);
+
+    let addr_field: field = addr as field;
+    if (merkle_proofs[0u32].leaf_index == merkle_proofs[1u32].leaf_index) {
+        // Ensure that if the address is the most left leaf, it is less than the first sibling
+        if (merkle_proofs[0u32].leaf_index == 0u32) {
+            assert(addr_field < merkle_proofs[0u32].siblings[0u32]);
+        } else {
+            // Ensure that if the address is the most right leaf
+            let last_index_leaf: u32 = 2u32 ** depth1 - 1u32;
+            assert_eq(merkle_proofs[0u32].leaf_index, last_index_leaf);
+            // Ensure that the address is bigger than the first sibling
+            assert(addr_field > merkle_proofs[0u32].siblings[0u32]);
+        }
+    } else {
+        // Ensure the address is in between the provided leaves
+        assert(addr_field > merkle_proofs[0u32].siblings[0u32]);
+        assert(addr_field < merkle_proofs[1u32].siblings[0u32]);
+        // Ensure that the leaf indexes are not greater than the last possible leaf index
+        let last_index_leaf: u32 = 2u32 ** depth1 - 1u32;
+        assert(merkle_proofs[1u32].leaf_index <= last_index_leaf);
+        // Ensure the leaves are adjacent
+        assert_eq(merkle_proofs[0u32].leaf_index + 1u32, merkle_proofs[1u32].leaf_index);
+    }
+
+    return root1;
+}
+
 program stable_token_1.aleo {
     @custom
-    async constructor() {
+    constructor() {
         // Only require multisig for upgrades - initial deployment has no checks.
         if self.edition > 0u16 {
             let signing_op_id = BHP256::hash_to_field(ChecksumEdition { checksum: self.checksum, edition: self.edition });
 
-            let wallet_signing_op_id_hash = BHP256::hash_to_field(multisig_core.aleo/WalletSigningOpId { wallet_id: self.address, signing_op_id: signing_op_id });
-            let signing_complete = multisig_core.aleo/completed_signing_ops.contains(wallet_signing_op_id_hash);
+            let wallet_signing_op_id_hash = BHP256::hash_to_field(multisig_core.aleo::WalletSigningOpId { wallet_id: self.address, signing_op_id: signing_op_id });
+            let signing_complete = multisig_core.aleo::completed_signing_ops.contains(wallet_signing_op_id_hash);
             assert(signing_complete);
         }
     }
 
     // A helper for calculating a signing_op_id from the program's checksum and edition.
     // By deriving the signing_op_id from both we ensure that downgrades cannot take place.
-    transition get_signing_op_id_for_deploy(checksum: [u8; 32], edition: u16) -> field {
+    fn get_signing_op_id_for_deploy(checksum: [u8; 32], edition: u16) -> field {
         return BHP256::hash_to_field(ChecksumEdition { checksum: checksum, edition: edition });
     }
 
@@ -38,29 +128,6 @@ program stable_token_1.aleo {
         freeze_list_root: field,
     }
 
-    struct MerkleProof {
-        siblings: [field; 16],
-        leaf_index: u32
-    }
-
-    struct ChecksumEdition {
-        checksum: [u8; 32],
-        edition: u16,
-    }
-
-    struct TokenInfo {
-        name: u128, // ASCII text represented in bits, and the u128 value of the bitstring
-        symbol: u128, // ASCII text represented in bits, and the u128 value of the bitstring
-        decimals: u8,
-        supply: u128,
-        max_supply: u128,
-    }
-
-    struct TokenAllowance {
-        account: address,
-        spender: address,
-    }
-    
     const TOKEN_INFO_INDEX: bool = true;
     // token specs
     mapping token_info: bool => TokenInfo;
@@ -101,76 +168,61 @@ program stable_token_1.aleo {
 
     // Updates the address assigned to a given role.
     // Can only be called by the current role manager.
-    async transition update_role(public new_address: address, role: u16) -> Future {
-        return f_update_role(new_address, self.caller, role);
-    }
-    async function f_update_role(new_address: address, caller: address, new_role: u16) {
-        let current_role: u16 = address_to_role.get(caller);
-        assert(current_role & MANAGER_ROLE == MANAGER_ROLE);
-        
-        if (caller == new_address) { 
-            assert(new_role & MANAGER_ROLE == MANAGER_ROLE); 
-        }
+    fn update_role(public new_address: address, role: u16) -> Final {
+        let caller: address = self.caller;
+        return final {
+            let current_role: u16 = address_to_role.get(caller);
+            assert(current_role & MANAGER_ROLE == MANAGER_ROLE);
 
-        address_to_role.set(new_address, new_role);
+            if (caller == new_address) {
+                assert(role & MANAGER_ROLE == MANAGER_ROLE);
+            }
 
+            address_to_role.set(new_address, role);
+        };
     }
 
     // Initializes the freeze list, token specifications, the admin and the investigator.
-    // Can be called only once and only by the INITIAL_ADMIN    
+    // Can be called only once and only by the INITIAL_ADMIN
     // Sets the token metadata (name, symbol, decimals, max supply).
     // Sets the block height window, the initial empty Merkle root,
     // and initialize the freeze_list_last_index, freeze_list, and freeze_list_index with a ZERO_ADDRESS placeholder.
-    async transition initialize(
+    fn initialize(
         public name: u128,
         public symbol: u128,
         public decimals: u8,
         public max_supply: u128,
         public admin: address,
-    ) -> Future {
-        return finalize_initialize(
-            name,
-            symbol,
-            decimals,
-            max_supply,
-            admin,
-            self.caller,
-        );
-    }
-    async function finalize_initialize(
-        name: u128,
-        symbol: u128,
-        decimals: u8,
-        max_supply: u128,
-        admin: address, 
-        caller: address,
-    ) {
-        // Check if the token has already been initialized
-        let already_initialized: bool = token_info.contains(TOKEN_INFO_INDEX);
-        assert_eq(already_initialized, false);
-        
-        // Only the INITIAL_CONFIGURATION_ADDRESS can initialize the contract
-        assert_eq(caller, DEPLOYER_ADDRESS);
-        
-        address_to_role.set(admin, MANAGER_ROLE);
+    ) -> Final {
+        let caller: address = self.caller;
+        return final {
+            // Check if the token has already been initialized
+            let already_initialized: bool = token_info.contains(TOKEN_INFO_INDEX);
+            assert_eq(already_initialized, false);
 
-        let token: TokenInfo = TokenInfo {
-            name: name,
-            symbol: symbol,
-            decimals: decimals,
-            supply: 0u128, // placeholder value; not used
-            max_supply: max_supply
+            // Only the INITIAL_CONFIGURATION_ADDRESS can initialize the contract
+            assert_eq(caller, DEPLOYER_ADDRESS);
+
+            address_to_role.set(admin, MANAGER_ROLE);
+
+            let token: TokenInfo = TokenInfo {
+                name: name,
+                symbol: symbol,
+                decimals: decimals,
+                supply: 0u128, // placeholder value; not used
+                max_supply: max_supply
+            };
+
+            token_info.set(TOKEN_INFO_INDEX, token);
+
+            pause.set(PAUSE_STATUS_INDEX, false);
         };
-
-        token_info.set(TOKEN_INFO_INDEX, token);
-
-        pause.set(PAUSE_STATUS_INDEX, false);
     }
 
     // Generates a Credential record for the signer.
     // Allows future private transfers without needing to re-prove non-inclusion in the freeze list.
     // The signer's privacy is preserved by proving non-inclusion in the freeze list Merkle tree.
-    async transition get_credentials(sender_merkle_proofs: [MerkleProof;2]) -> (Credentials, Future) {
+    fn get_credentials(sender_merkle_proofs: [MerkleProof;2]) -> (Credentials, Final) {
         let root: field = verify_non_inclusion(self.signer, sender_merkle_proofs);
 
         let credentials_record: Credentials = Credentials {
@@ -178,71 +230,65 @@ program stable_token_1.aleo {
             freeze_list_root: root,
         };
 
-        return (credentials_record, f_get_credentials(root));
-    }
-    async function f_get_credentials(root: field) {
-        let current_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
-        let window: u32 = sealance_freezelist_registry.aleo/block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
+        return (credentials_record, final {
+            let current_root: field = sealance_freezelist_registry.aleo::freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+            let window: u32 = sealance_freezelist_registry.aleo::block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
 
-        if (current_root != root) {
-            let previous_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
-            assert_eq(root, previous_root);
-            let updated_height: u32 = sealance_freezelist_registry.aleo/root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
-            assert(updated_height + window > block.height);
-        }
+            if (current_root != root) {
+                let previous_root: field = sealance_freezelist_registry.aleo::freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+                assert_eq(root, previous_root);
+                let updated_height: u32 = sealance_freezelist_registry.aleo::root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+                assert(updated_height + window > block.height);
+            }
+        });
     }
 
-    // Mints new public tokens to the specified recipient’s balance.
+    // Mints new public tokens to the specified recipient's balance.
     // Can only be called by a minter.
     // Ensures that the new total supply does not exceed the maximum supply.
-    // Updates the recipient’s balance and the total token supply in the token metadata.
-    async transition mint_public(
+    // Updates the recipient's balance and the total token supply in the token metadata.
+    fn mint_public(
         public recipient: address,
         public amount: u128,
-    ) -> Future {
-        return finalize_mint_public(recipient, amount, self.caller);
-    }
-    async function finalize_mint_public(
-        recipient: address,
-        amount: u128,
-        caller: address
-    ) {
+    ) -> Final {
+        let caller: address = self.caller;
+        return final {
+            let role: u16 = address_to_role.get(caller);
+            assert(role & MINTER_ROLE == MINTER_ROLE);
 
-        let role: u16 = address_to_role.get(caller);
-        assert(role & MINTER_ROLE == MINTER_ROLE);
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
+            let token = token_info.get(TOKEN_INFO_INDEX);
+            // Check that the token supply + amount <= max_supply
+            let new_supply: u128 = token.supply + amount;
+            assert(new_supply <= token.max_supply);
 
-        let token = token_info.get(TOKEN_INFO_INDEX);
-        // Check that the token supply + amount <= max_supply
-        let new_supply: u128 = token.supply + amount;
-        assert(new_supply <= token.max_supply);
+            // Update the balance
+            let balance = balances.get_or_use(recipient, 0u128);
+            let new_balance = amount + balance;
+            balances.set(recipient, new_balance);
 
-        // Update the balance
-        let balance = balances.get_or_use(recipient, 0u128);
-        let new_balance = amount + balance;
-        balances.set(recipient, new_balance);
-
-        // Update the token supply
-        let new_metadata: TokenInfo = TokenInfo {
-            name: token.name,
-            symbol: token.symbol,
-            decimals: token.decimals,
-            supply: new_supply,
-            max_supply: token.max_supply,
+            // Update the token supply
+            let new_metadata: TokenInfo = TokenInfo {
+                name: token.name,
+                symbol: token.symbol,
+                decimals: token.decimals,
+                supply: new_supply,
+                max_supply: token.max_supply,
+            };
+            token_info.set(TOKEN_INFO_INDEX, new_metadata);
         };
-        token_info.set(TOKEN_INFO_INDEX, new_metadata);
     }
 
     // Mints new private tokens to the specified recipient.
     // Can only be called by a minter.
     // Ensures that the new total supply does not exceed the maximum supply.
     // Updates the total token supply in the token metadata.
-    async transition mint_private(
+    fn mint_private(
         recipient: address,
         public amount: u128,
-        ) -> (ComplianceRecord, Token, Future) {
+        ) -> (ComplianceRecord, Token, Final) {
         let token: Token = Token {
             owner: recipient,
             amount: amount,
@@ -254,82 +300,73 @@ program stable_token_1.aleo {
             sender: ZERO_ADDRESS,
             recipient: recipient,
         };
-        
-        return (compliance_record, token, finalize_mint_private(amount, self.caller));
+
+        let caller: address = self.caller;
+        return (compliance_record, token, final {
+            let role: u16 = address_to_role.get(caller);
+            assert(role & MINTER_ROLE == MINTER_ROLE);
+
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
+
+            let token_metadata = token_info.get(TOKEN_INFO_INDEX);
+
+            // Check that the token supply + amount <= max_supply
+            let new_supply: u128 = token_metadata.supply + amount;
+            assert(new_supply <= token_metadata.max_supply);
+
+            // Update the token supply
+            let new_metadata: TokenInfo = TokenInfo {
+                name: token_metadata.name,
+                symbol: token_metadata.symbol,
+                decimals: token_metadata.decimals,
+                supply: new_supply,
+                max_supply: token_metadata.max_supply,
+            };
+            token_info.set(TOKEN_INFO_INDEX, new_metadata);
+        });
     }
 
-    async function finalize_mint_private(
-        amount: u128,
-        caller: address,
-    ) {
-        let role: u16 = address_to_role.get(caller);
-        assert(role & MINTER_ROLE == MINTER_ROLE);
-
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
-
-        let token = token_info.get(TOKEN_INFO_INDEX);
-
-        // Check that the token supply + amount <= max_supply
-        let new_supply: u128 = token.supply + amount;
-        assert(new_supply <= token.max_supply);
-
-        // Update the token supply
-        let new_metadata: TokenInfo = TokenInfo {
-            name: token.name,
-            symbol: token.symbol,
-            decimals: token.decimals,
-            supply: new_supply,
-            max_supply: token.max_supply,
-        };
-        token_info.set(TOKEN_INFO_INDEX, new_metadata);
-    }
-
-    // Burns public tokens from the specified owner’s balance.
+    // Burns public tokens from the specified owner's balance.
     // Can only be called by a burner.
-    // Decreases the owner’s balance and reduces the total token supply in the token metadata.
-    async transition burn_public(
+    // Decreases the owner's balance and reduces the total token supply in the token metadata.
+    fn burn_public(
         public owner: address,
         public amount: u128
-    ) -> Future {
-        return finalize_burn_public(owner, amount, self.caller);
-    }
+    ) -> Final {
+        let caller: address = self.caller;
+        return final {
+            let role: u16 = address_to_role.get(caller);
+            assert(role & BURNER_ROLE == BURNER_ROLE);
 
-    async function finalize_burn_public(
-        owner: address,
-        amount: u128,
-        caller: address,
-    ) {
-        let role: u16 = address_to_role.get(caller);
-        assert(role & BURNER_ROLE == BURNER_ROLE);
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
+            // Update the balance
+            let balance = balances.get(owner);
+            let new_balance = balance - amount;
+            balances.set(owner, new_balance);
 
-        // Update the balance
-        let balance = balances.get(owner);
-        let new_balance = balance - amount;
-        balances.set(owner, new_balance);
+            let token = token_info.get(TOKEN_INFO_INDEX);
 
-        let token = token_info.get(TOKEN_INFO_INDEX);
-
-        let new_metadata: TokenInfo = TokenInfo {
-            name: token.name,
-            symbol: token.symbol,
-            decimals: token.decimals,
-            supply: token.supply - amount, // underflow will be caught by the VM
-            max_supply: token.max_supply,
+            let new_metadata: TokenInfo = TokenInfo {
+                name: token.name,
+                symbol: token.symbol,
+                decimals: token.decimals,
+                supply: token.supply - amount, // underflow will be caught by the VM
+                max_supply: token.max_supply,
+            };
+            token_info.set(TOKEN_INFO_INDEX, new_metadata);
         };
-        token_info.set(TOKEN_INFO_INDEX, new_metadata);
     }
 
     // Burns tokens from a private record (non-public asset).
     // Can only be called by a burner.
     // Reduces the amount in the provided private record and decreases the total token supply in the token metadata.
-    async transition burn_private(
+    fn burn_private(
         input_record: Token,
         public amount: u128
-    ) -> (ComplianceRecord, Token, Future) {
+    ) -> (ComplianceRecord, Token, Final) {
         let output_record: Token = Token {
             owner: input_record.owner,
             amount: input_record.amount - amount
@@ -342,29 +379,26 @@ program stable_token_1.aleo {
             recipient: ZERO_ADDRESS,
         };
 
-        return (compliance_record, output_record, finalize_burn_private(amount, self.caller));
-    }
-    async function finalize_burn_private(
-        amount: u128,
-        caller: address,
-    ) {
-        let role: u16 = address_to_role.get(caller);
-        assert(role & BURNER_ROLE == BURNER_ROLE);
+        let caller: address = self.caller;
+        return (compliance_record, output_record, final {
+            let role: u16 = address_to_role.get(caller);
+            assert(role & BURNER_ROLE == BURNER_ROLE);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-        let token = token_info.get(TOKEN_INFO_INDEX);
+            let token = token_info.get(TOKEN_INFO_INDEX);
 
-        // Update the token supply
-        let new_metadata: TokenInfo = TokenInfo {
-            name: token.name,
-            symbol: token.symbol,
-            decimals: token.decimals,
-            supply: token.supply - amount, // underflow will be caught by the VM
-            max_supply: token.max_supply,
-        };
-        token_info.set(TOKEN_INFO_INDEX, new_metadata);
+            // Update the token supply
+            let new_metadata: TokenInfo = TokenInfo {
+                name: token.name,
+                symbol: token.symbol,
+                decimals: token.decimals,
+                supply: token.supply - amount, // underflow will be caught by the VM
+                max_supply: token.max_supply,
+            };
+            token_info.set(TOKEN_INFO_INDEX, new_metadata);
+        });
     }
 
     // -------------------------
@@ -373,170 +407,142 @@ program stable_token_1.aleo {
 
     // Transfers public tokens from the caller to the recipient.
     // Both sender and recipient must not be frozen in the freeze list.
-    async transition transfer_public(
+    fn transfer_public(
         public recipient: address,
         public amount: u128
-    ) -> Future {
-        return finalize_transfer_public(recipient, amount, self.caller);
-    }
+    ) -> Final {
+        let caller: address = self.caller;
+        return final {
+            let is_sender_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(caller, false);
+            assert_eq(is_sender_frozen, false);
+            let is_recipient_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(recipient, false);
+            assert_eq(is_recipient_frozen, false);
 
-    async function finalize_transfer_public(
-        recipient: address,
-        amount: u128,
-        sender: address
-    ) {
-        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
-        assert_eq(is_sender_frozen, false);
-        let is_recipient_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(recipient, false);
-        assert_eq(is_recipient_frozen, false);
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
+            let sender_balance = balances.get(caller);
+            balances.set(caller, sender_balance - amount);
 
-        let sender_balance = balances.get(sender);
-        balances.set(sender, sender_balance - amount);
-
-        let recipient_balance = balances.get_or_use(recipient, 0u128);
-        balances.set(recipient, recipient_balance + amount);
+            let recipient_balance = balances.get_or_use(recipient, 0u128);
+            balances.set(recipient, recipient_balance + amount);
+        };
     }
 
     // Transfers public tokens from the signer to the recipient.
     // Both sender and recipient must not be frozen in the freeze list.
-    async transition transfer_public_as_signer(
+    fn transfer_public_as_signer(
         public recipient: address,
         public amount: u128
-    ) -> Future {
-        return f_transfer_public_as_signer(recipient, amount, self.signer);
+    ) -> Final {
+        let signer: address = self.signer;
+        return final {
+            let is_sender_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(signer, false);
+            assert_eq(is_sender_frozen, false);
+            let is_recipient_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(recipient, false);
+            assert_eq(is_recipient_frozen, false);
+
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
+
+            let sender_balance = balances.get(signer);
+            balances.set(signer, sender_balance - amount);
+
+            let recipient_balance = balances.get_or_use(recipient, 0u128);
+            balances.set(recipient, recipient_balance + amount);
+        };
     }
 
-    async function f_transfer_public_as_signer(
-        recipient: address,
-        amount: u128,
-        sender: address
-    ) {
-        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
-        assert_eq(is_sender_frozen, false);
-        let is_recipient_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(recipient, false);
-        assert_eq(is_recipient_frozen, false);
-
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
-
-        let sender_balance = balances.get(sender);
-        balances.set(sender, sender_balance - amount);
-
-        let recipient_balance = balances.get_or_use(recipient, 0u128);
-        balances.set(recipient, recipient_balance + amount);
-    }
-
-    // Approves a spender to transfer the caller’s public assets up to a specified amount.
+    // Approves a spender to transfer the caller's public assets up to a specified amount.
     // Increases the existing allowance if one is already set, otherwise creates a new allowance.
-    // The allowance is stored using a hash of the owner–spender pair as the key.
-    async transition approve_public(
+    // The allowance is stored using a hash of the owner-spender pair as the key.
+    fn approve_public(
         public spender: address,
         public amount: u128
-    ) -> Future {
+    ) -> Final {
         let allowance: TokenAllowance = TokenAllowance {
             account: self.caller,
             spender: spender
         };
         let allowance_key: field = BHP256::hash_to_field(allowance);
 
-        return finalize_approve_public(amount, allowance_key);
+        return final {
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
+
+            let current_allowance: u128 = allowances.get_or_use(allowance_key, 0u128);
+            // Increase or create the allowance amount
+            allowances.set(allowance_key, current_allowance + amount);
+        };
     }
 
-    async function finalize_approve_public(
-        amount: u128,
-        allowance_key: field
-    ) {
-
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
-
-        let current_allowance: u128 = allowances.get_or_use(allowance_key, 0u128);
-        // Increase or create the allowance amount
-        allowances.set(allowance_key, current_allowance + amount);
-    }
-
-    // Reduces a spender’s allowance to transfer the caller’s public assets by a specified amount.
-    // Decreases the existing allowance stored under the hash of the owner–spender pair.
+    // Reduces a spender's allowance to transfer the caller's public assets by a specified amount.
+    // Decreases the existing allowance stored under the hash of the owner-spender pair.
     // If the reduction exceeds the current allowance, the VM will catch the underflow.
-    async transition unapprove_public(
+    fn unapprove_public(
         public spender: address,
         public amount: u128
-    ) -> Future {
+    ) -> Final {
         let allowance: TokenAllowance = TokenAllowance {
             account: self.caller,
             spender: spender
         };
         let allowance_key: field = BHP256::hash_to_field(allowance);
 
-        return finalize_unapprove_public(amount, allowance_key);
-    }
-    async function finalize_unapprove_public(
-        amount: u128,
-        allowance_key: field
-    ) {
+        return final {
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
-
-        let current_allowance: u128 = allowances.get(allowance_key);
-        // Decrease the allowance amount
-        allowances.set(allowance_key, current_allowance - amount);
+            let current_allowance: u128 = allowances.get(allowance_key);
+            // Decrease the allowance amount
+            allowances.set(allowance_key, current_allowance - amount);
+        };
     }
 
     // Transfers public tokens from the owner to the recipient.
     // Can be called by any spender with sufficient allowance from the owner.
-    // Decreases the spender’s allowance by the transferred amount.
+    // Decreases the spender's allowance by the transferred amount.
     // Both sender and recipient must not be frozen in the freeze list.
-    async transition transfer_from_public(
+    fn transfer_from_public(
         public owner: address,
         public recipient: address,
         public amount: u128
-    ) -> Future {
+    ) -> Final {
         let allowance: TokenAllowance = TokenAllowance {
             account: owner,
             spender: self.caller,
         };
         let allowance_key: field = BHP256::hash_to_field(allowance);
 
-        return finalize_transfer_from_public(owner, recipient, amount, allowance_key);
-    }
+        return final {
+            let is_sender_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(owner, false);
+            assert_eq(is_sender_frozen, false);
+            let is_recipient_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(recipient, false);
+            assert_eq(is_recipient_frozen, false);
 
-    async function finalize_transfer_from_public(
-        sender: address,
-        recipient: address,
-        amount: u128,
-        allowance_key: field
-    ) {
-        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
-        assert_eq(is_sender_frozen, false);
-        let is_recipient_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(recipient, false);
-        assert_eq(is_recipient_frozen, false);
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
+            // Check that the spender is authorized to spend the amount
+            let current_allowance: u128 = allowances.get(allowance_key);
+            // Decrease the allowance by the amount being spent
+            allowances.set(allowance_key, current_allowance - amount);
 
-        // Check that the spender is authorized to spend the amount
-        let current_allowance: u128 = allowances.get(allowance_key);
-        // Decrease the allowance by the amount being spent
-        allowances.set(allowance_key, current_allowance - amount);
+            let sender_balance = balances.get(owner);
+            balances.set(owner, sender_balance - amount);
 
-        let sender_balance = balances.get(sender);
-        balances.set(sender, sender_balance - amount);
-
-        let recipient_balance = balances.get_or_use(recipient, 0u128);
-        balances.set(recipient, recipient_balance + amount);
+            let recipient_balance = balances.get_or_use(recipient, 0u128);
+            balances.set(recipient, recipient_balance + amount);
+        };
     }
 
     // Transfers public tokens from the caller to a recipient as a private token.
     // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
     // The sender must not be frozen in the freeze list.
-    async transition transfer_public_to_private(
+    fn transfer_public_to_private(
         recipient: address,
         public amount: u128,
-    ) -> (ComplianceRecord, Token, Future) {
+    ) -> (ComplianceRecord, Token, Final) {
         let token: Token = Token {
             owner: recipient,
             amount: amount
@@ -549,33 +555,29 @@ program stable_token_1.aleo {
             recipient: recipient,
         };
 
-        return (compliance_record, token, f_transfer_public_to_private(amount, self.caller));
-    }
+        let caller: address = self.caller;
+        return (compliance_record, token, final {
+            let is_sender_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(caller, false);
+            assert_eq(is_sender_frozen, false);
 
-    async function f_transfer_public_to_private(
-        amount: u128,
-        sender: address,
-    ) {
-        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
-        assert_eq(is_sender_frozen, false);
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
-
-        let sender_balance = balances.get(sender);
-        balances.set(sender, sender_balance - amount);
+            let sender_balance = balances.get(caller);
+            balances.set(caller, sender_balance - amount);
+        });
     }
 
     // Transfers public tokens from an owner to a recipient as a private token.
     // Can be called by any spender with sufficient allowance from the owner.
-    // Decreases the spender’s allowance by the transferred amount.
+    // Decreases the spender's allowance by the transferred amount.
     // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
     // The sender must not be frozen in the freeze list.
-    async transition transfer_from_public_to_private(
+    fn transfer_from_public_to_private(
         public owner: address,
         recipient: address,
         public amount: u128,
-    ) -> (ComplianceRecord, Token, Future) {
+    ) -> (ComplianceRecord, Token, Final) {
 
         let token: Token = Token {
             owner: recipient,
@@ -595,39 +597,33 @@ program stable_token_1.aleo {
             recipient: recipient,
         };
 
-        return (compliance_record, token, f_transfer_from_public_to_priv(owner, amount, allowance_key));
-    }
+        return (compliance_record, token, final {
+            let is_sender_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(owner, false);
+            assert_eq(is_sender_frozen, false);
 
-    async function f_transfer_from_public_to_priv(
-        sender: address,
-        amount: u128,
-        allowance_key: field,
-    ) {
-        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
-        assert_eq(is_sender_frozen, false);
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
+            // Check that the spender is authorized to spend the amount
+            let current_allowance: u128 = allowances.get(allowance_key);
+            // Decrease the allowance by the amount being spent
+            allowances.set(allowance_key, current_allowance - amount);
 
-        // Check that the spender is authorized to spend the amount
-        let current_allowance: u128 = allowances.get(allowance_key);
-        // Decrease the allowance by the amount being spent
-        allowances.set(allowance_key, current_allowance - amount);
-
-        let sender_balance = balances.get(sender);
-        balances.set(sender, sender_balance - amount);
+            let sender_balance = balances.get(owner);
+            balances.set(owner, sender_balance - amount);
+        });
     }
 
     // Transfers private tokens from the record owner to a recipient.
     // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
     // The sender must not be frozen in the freeze list.
     // The sender's privacy is preserved by proving non-inclusion in the freeze list Merkle tree.
-    async transition transfer_private(
+    fn transfer_private(
         recipient: address,
         amount: u128,
         input_record: Token,
         sender_merkle_proofs: [MerkleProof;2],
-    ) -> (ComplianceRecord, Token, Token, Future) {
+    ) -> (ComplianceRecord, Token, Token, Final) {
         let sender_root: field = verify_non_inclusion(input_record.owner, sender_merkle_proofs);
 
         let updated_record: Token = Token {
@@ -647,23 +643,20 @@ program stable_token_1.aleo {
             recipient: recipient,
         };
 
-        return (compliance_record, updated_record, transfer_record, f_transfer_private(sender_root));
-    }
+        return (compliance_record, updated_record, transfer_record, final {
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-    async function f_transfer_private(root: field) {
+            let current_root: field = sealance_freezelist_registry.aleo::freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+            let window: u32 = sealance_freezelist_registry.aleo::block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
-
-        let current_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
-        let window: u32 = sealance_freezelist_registry.aleo/block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
-
-        if (current_root != root) {
-            let previous_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
-            assert_eq(root, previous_root);
-            let updated_height: u32 = sealance_freezelist_registry.aleo/root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
-            assert(updated_height + window > block.height);
-        }
+            if (current_root != sender_root) {
+                let previous_root: field = sealance_freezelist_registry.aleo::freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+                assert_eq(sender_root, previous_root);
+                let updated_height: u32 = sealance_freezelist_registry.aleo::root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+                assert(updated_height + window > block.height);
+            }
+        });
     }
 
     // Transfers private tokens from the record owner to a recipient as a public tokens.
@@ -671,12 +664,12 @@ program stable_token_1.aleo {
     // A Credentials record is emitted for the sender
     // Both sender and recipient must not be frozen in the freeze list.
     // The sender's privacy is preserved by proving non-inclusion in the freeze list Merkle tree.
-    async transition transfer_private_to_public(
+    fn transfer_private_to_public(
         public recipient: address,
         public amount: u128,
         input_record: Token,
         sender_merkle_proofs: [MerkleProof; 2],
-    ) -> (ComplianceRecord, Token, Future) {
+    ) -> (ComplianceRecord, Token, Final) {
         let root: field = verify_non_inclusion(input_record.owner, sender_merkle_proofs);
 
         let updated_record: Token = Token {
@@ -694,54 +687,43 @@ program stable_token_1.aleo {
         return (
             compliance_record,
             updated_record,
-            f_transfer_private_to_public(
-                root,
-                recipient,
-                amount
-            )
+            final {
+                let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+                assert_eq(is_paused, false);
+
+                let current_root: field = sealance_freezelist_registry.aleo::freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+                let window: u32 = sealance_freezelist_registry.aleo::block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
+
+                if (current_root != root) {
+                    let previous_root: field = sealance_freezelist_registry.aleo::freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+                    assert_eq(root, previous_root);
+                    let updated_height: u32 = sealance_freezelist_registry.aleo::root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+                    assert(updated_height + window > block.height);
+                }
+
+                let is_recipient_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(recipient, false);
+                assert_eq(is_recipient_frozen, false);
+
+                let recipient_balance = balances.get_or_use(recipient, 0u128);
+                balances.set(recipient, recipient_balance + amount);
+            }
         );
-    }
-
-    async function f_transfer_private_to_public(
-        root: field,
-        recipient: address,
-        amount: u128    ) {
-        
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
-
-        let current_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
-        let window: u32 = sealance_freezelist_registry.aleo/block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
-
-        if (current_root != root) {
-            let previous_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
-            assert_eq(root, previous_root);
-            let updated_height: u32 = sealance_freezelist_registry.aleo/root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
-            assert(updated_height + window > block.height);
-        } 
-
-        let is_recipient_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(recipient, false);
-        assert_eq(is_recipient_frozen, false);
-
-        let recipient_balance = balances.get_or_use(recipient, 0u128);
-        balances.set(recipient, recipient_balance + amount);
     }
 
     // Stops or resumes all token transfers.
     // Can only be called by an address with the PAUSE_ROLE.
-    async transition set_pause_status(pause_status: bool) -> Future {
-        return f_set_pause_status(pause_status, self.caller);
+    fn set_pause_status(pause_status: bool) -> Final {
+        let caller: address = self.caller;
+        return final {
+            let role: u16 = address_to_role.get(caller);
+            assert(role & PAUSE_ROLE == PAUSE_ROLE);
+
+            pause.set(PAUSE_STATUS_INDEX, pause_status);
+        };
     }
 
-    async function f_set_pause_status(new_pause_status: bool, caller: address) {
-        let role: u16 = address_to_role.get(caller);
-        assert(role & PAUSE_ROLE == PAUSE_ROLE);
-        
-        pause.set(PAUSE_STATUS_INDEX, new_pause_status);
-    }
 
-
-    transition join(
+    fn join(
         private token_1: Token,
         private token_2: Token
     ) -> Token {
@@ -753,7 +735,7 @@ program stable_token_1.aleo {
         return new_token;
     }
 
-    transition split(
+    fn split(
         private token: Token,
         private amount: u128
     ) -> (Token, Token) {
@@ -773,12 +755,12 @@ program stable_token_1.aleo {
     // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
     // The sender must not be frozen in the freeze list.
     // The sender's privacy is preserved by using a Credentials record.
-    async transition transfer_private_with_creds(
+    fn transfer_private_with_creds(
         recipient: address,
         amount: u128,
         input_record: Token,
         credentials: Credentials,
-    ) -> (ComplianceRecord, Token, Token, Credentials, Future) {
+    ) -> (ComplianceRecord, Token, Token, Credentials, Final) {
         let updated_record: Token = Token {
             owner: input_record.owner,
             amount: input_record.amount - amount
@@ -801,89 +783,20 @@ program stable_token_1.aleo {
             freeze_list_root: credentials.freeze_list_root,
         };
 
-        return (compliance_record, updated_record, transfer_record, credentials_record, f_transfer_private_credentials(credentials.freeze_list_root));
-    }
+        let creds_root: field = credentials.freeze_list_root;
+        return (compliance_record, updated_record, transfer_record, credentials_record, final {
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-    async function f_transfer_private_credentials(root: field) {
+            let current_root: field = sealance_freezelist_registry.aleo::freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+            let window: u32 = sealance_freezelist_registry.aleo::block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
-
-        let current_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
-        let window: u32 = sealance_freezelist_registry.aleo/block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
-
-        if (current_root != root) {
-            let previous_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
-            assert_eq(root, previous_root);
-            let updated_height: u32 = sealance_freezelist_registry.aleo/root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
-            assert(updated_height + window > block.height);
-        }
-    }
-
-    // Calculates the hash of two sibling nodes in a Merkle tree.
-    // The order of the siblings depends on the index bit (0 = left, 1 = right).
-    // Uses Poseidon hash to compute the result.
-    inline calculate_hash_for_nodes(sibling1: field, sibling2: field, indexbit: u32) -> field {
-        let poseidon_params: [field; 3] = indexbit == 0u32 ? [0field, sibling1, sibling2] : [0field, sibling2, sibling1];
-        return Poseidon4::hash_to_field(poseidon_params);
-    }
-
-    inline calculate_hash_for_leaves(sibling1: field, sibling2: field, indexbit: u32) -> field {
-        let poseidon_params: [field; 3] = indexbit == 0u32 ? [1field, sibling1, sibling2] : [1field, sibling2, sibling1];
-        return Poseidon4::hash_to_field(poseidon_params);
-    }
-
-    // Calculates the Merkle root and the depth of a Merkle proof path.
-    // Iteratively hashes the sibling path based on the leaf index to reconstruct the root.
-    // Stops when a zero field is encountered in the siblings array, indicating the end of the valid path.
-    // Returns the calculated root and the actual depth reached.
-    inline calculate_root_depth_siblings(merkle_proof: MerkleProof) -> (public field, public u32) {
-        let root: field = calculate_hash_for_leaves(merkle_proof.siblings[0u8], merkle_proof.siblings[1u8],  merkle_proof.leaf_index % 2u32);
-        for i: u32 in 2u32..MAX_TREE_DEPTH + 1u32 {
-            if (merkle_proof.siblings[i] == 0field) {
-                return (root, i - 1u32);
+            if (current_root != creds_root) {
+                let previous_root: field = sealance_freezelist_registry.aleo::freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+                assert_eq(creds_root, previous_root);
+                let updated_height: u32 = sealance_freezelist_registry.aleo::root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+                assert(updated_height + window > block.height);
             }
-            root = calculate_hash_for_nodes(root, merkle_proof.siblings[i], (merkle_proof.leaf_index / (2u32**(i-1u32))) % 2u32);
-        }
-        return (root, MAX_TREE_DEPTH);
-    }
-
-    // Verifies non-inclusion of an address in a Merkle tree sorted in ascending order by address (as field).
-    // Accepts two Merkle proofs representing the neighboring leaves around the missing address.
-    // Returns the common Merkle root if the address is proven to be outside the tree.
-    // If the tree is not sorted correctly, this function may return incorrect results.
-    inline verify_non_inclusion(addr: address, merkle_proofs: [MerkleProof;2]) -> field {
-        let (root1, depth1): (field, u32)= calculate_root_depth_siblings(merkle_proofs[0u32]);
-        let (root2, depth2): (field, u32) = calculate_root_depth_siblings(merkle_proofs[1u32]);
-
-        // Ensure the roots from the merkle proofs are the same
-        assert_eq(root1, root2);
-        // Ensure the depth of the merkle proofs is the same
-        assert_eq(depth1, depth2);
-        
-        let addr_field: field = addr as field;
-        if (merkle_proofs[0u32].leaf_index == merkle_proofs[1u32].leaf_index) {
-            // Ensure that if the address is the most left leaf, it is less than the first sibling
-            if (merkle_proofs[0u32].leaf_index == 0u32) {
-                assert(addr_field < merkle_proofs[0u32].siblings[0u32]);
-            } else {
-                // Ensure that if the address is the most right leaf
-                let last_index_leaf: u32 = 2u32 ** depth1 - 1u32;
-                assert_eq(merkle_proofs[0u32].leaf_index, last_index_leaf);
-                // Ensure that the address is bigger than the first sibling
-                assert(addr_field > merkle_proofs[0u32].siblings[0u32]);
-            }
-        } else {
-            // Ensure the address is in between the provided leaves
-            assert(addr_field > merkle_proofs[0u32].siblings[0u32]);
-            assert(addr_field < merkle_proofs[1u32].siblings[0u32]);
-            // Ensure that the leaf indexes are not greater than the last possible leaf index
-            let last_index_leaf: u32 = 2u32 ** depth1 - 1u32;
-            assert(merkle_proofs[1u32].leaf_index <= last_index_leaf);
-            // Ensure the leaves are adjacent
-            assert_eq(merkle_proofs[0u32].leaf_index + 1u32, merkle_proofs[1u32].leaf_index);
-        }
-        
-        return root1;
+        });
     }
 }

--- a/programs/amm/stable_token_2.leo
+++ b/programs/amm/stable_token_2.leo
@@ -1,0 +1,889 @@
+import sealance_freezelist_registry.aleo;
+import multisig_core.aleo;
+
+program stable_token_2.aleo {
+    @custom
+    async constructor() {
+        // Only require multisig for upgrades - initial deployment has no checks.
+        if self.edition > 0u16 {
+            let signing_op_id = BHP256::hash_to_field(ChecksumEdition { checksum: self.checksum, edition: self.edition });
+
+            let wallet_signing_op_id_hash = BHP256::hash_to_field(multisig_core.aleo/WalletSigningOpId { wallet_id: self.address, signing_op_id: signing_op_id });
+            let signing_complete = multisig_core.aleo/completed_signing_ops.contains(wallet_signing_op_id_hash);
+            assert(signing_complete);
+        }
+    }
+
+    // A helper for calculating a signing_op_id from the program's checksum and edition.
+    // By deriving the signing_op_id from both we ensure that downgrades cannot take place.
+    transition get_signing_op_id_for_deploy(checksum: [u8; 32], edition: u16) -> field {
+        return BHP256::hash_to_field(ChecksumEdition { checksum: checksum, edition: edition });
+    }
+
+    record Token {
+        owner: address,
+        amount: u128
+    }
+
+    // Compliance record used for the investigator
+    record ComplianceRecord {
+        owner: address,
+        amount: u128,
+        sender: address,
+        recipient: address
+    }
+
+    record Credentials {
+        owner: address,
+        freeze_list_root: field,
+    }
+
+    struct MerkleProof {
+        siblings: [field; 16],
+        leaf_index: u32
+    }
+
+    struct ChecksumEdition {
+        checksum: [u8; 32],
+        edition: u16,
+    }
+
+    struct TokenInfo {
+        name: u128, // ASCII text represented in bits, and the u128 value of the bitstring
+        symbol: u128, // ASCII text represented in bits, and the u128 value of the bitstring
+        decimals: u8,
+        supply: u128,
+        max_supply: u128,
+    }
+
+    struct TokenAllowance {
+        account: address,
+        spender: address,
+    }
+    
+    const TOKEN_INFO_INDEX: bool = true;
+    // token specs
+    mapping token_info: bool => TokenInfo;
+
+    mapping balances: address => u128;
+    mapping allowances: field => u128; // hash(account, spender) => TokenAllowance
+
+    // Roles can be assigned using bitmasking to allow multiple roles per address
+    const NONE_ROLE: u16 = 0u16;
+    const MINTER_ROLE: u16 = 1u16;
+    const BURNER_ROLE: u16 = 2u16;
+    const PAUSE_ROLE: u16 = 4u16;   // can pause/unpause transfers
+    const MANAGER_ROLE: u16 = 8u16; // can only assign roles
+    mapping address_to_role: address => u16;
+
+    // Only this address can deploy and initialize the program
+    const DEPLOYER_ADDRESS: address = aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px;
+
+    // This address receives compliance records (can be updated with the contract upgrade)
+    const INVESTIGATOR_ADDRESS: address = aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px;
+
+    const PAUSE_STATUS_INDEX: bool = true;
+    mapping pause: bool => bool;
+
+    const ZERO_ADDRESS: address = aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc; // ZERO_ADDRESS as field equals to 0field
+    const CURRENT_FREEZE_LIST_ROOT_INDEX: u8 = 1u8;
+    const PREVIOUS_FREEZE_LIST_ROOT_INDEX: u8 = 2u8;
+    const BLOCK_HEIGHT_WINDOW_INDEX: bool = true;
+    const ROOT_UPDATED_HEIGHT_INDEX: bool = true;
+    // Maximum depth of the Merkle tree used in freeze list proofs.
+    // The siblings array has MAX_TREE_DEPTH + 1 elements because siblings[0] holds the leaf itself.
+    const MAX_TREE_DEPTH: u32 = 15u32;
+
+    // -------------------------
+    // Called by token admins
+    // -------------------------
+
+
+    // Updates the address assigned to a given role.
+    // Can only be called by the current role manager.
+    async transition update_role(public new_address: address, role: u16) -> Future {
+        return f_update_role(new_address, self.caller, role);
+    }
+    async function f_update_role(new_address: address, caller: address, new_role: u16) {
+        let current_role: u16 = address_to_role.get(caller);
+        assert(current_role & MANAGER_ROLE == MANAGER_ROLE);
+        
+        if (caller == new_address) { 
+            assert(new_role & MANAGER_ROLE == MANAGER_ROLE); 
+        }
+
+        address_to_role.set(new_address, new_role);
+
+    }
+
+    // Initializes the freeze list, token specifications, the admin and the investigator.
+    // Can be called only once and only by the INITIAL_ADMIN    
+    // Sets the token metadata (name, symbol, decimals, max supply).
+    // Sets the block height window, the initial empty Merkle root,
+    // and initialize the freeze_list_last_index, freeze_list, and freeze_list_index with a ZERO_ADDRESS placeholder.
+    async transition initialize(
+        public name: u128,
+        public symbol: u128,
+        public decimals: u8,
+        public max_supply: u128,
+        public admin: address,
+    ) -> Future {
+        return finalize_initialize(
+            name,
+            symbol,
+            decimals,
+            max_supply,
+            admin,
+            self.caller,
+        );
+    }
+    async function finalize_initialize(
+        name: u128,
+        symbol: u128,
+        decimals: u8,
+        max_supply: u128,
+        admin: address, 
+        caller: address,
+    ) {
+        // Check if the token has already been initialized
+        let already_initialized: bool = token_info.contains(TOKEN_INFO_INDEX);
+        assert_eq(already_initialized, false);
+        
+        // Only the INITIAL_CONFIGURATION_ADDRESS can initialize the contract
+        assert_eq(caller, DEPLOYER_ADDRESS);
+        
+        address_to_role.set(admin, MANAGER_ROLE);
+
+        let token: TokenInfo = TokenInfo {
+            name: name,
+            symbol: symbol,
+            decimals: decimals,
+            supply: 0u128, // placeholder value; not used
+            max_supply: max_supply
+        };
+
+        token_info.set(TOKEN_INFO_INDEX, token);
+
+        pause.set(PAUSE_STATUS_INDEX, false);
+    }
+
+    // Generates a Credential record for the signer.
+    // Allows future private transfers without needing to re-prove non-inclusion in the freeze list.
+    // The signer's privacy is preserved by proving non-inclusion in the freeze list Merkle tree.
+    async transition get_credentials(sender_merkle_proofs: [MerkleProof;2]) -> (Credentials, Future) {
+        let root: field = verify_non_inclusion(self.signer, sender_merkle_proofs);
+
+        let credentials_record: Credentials = Credentials {
+            owner: self.signer,
+            freeze_list_root: root,
+        };
+
+        return (credentials_record, f_get_credentials(root));
+    }
+    async function f_get_credentials(root: field) {
+        let current_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+        let window: u32 = sealance_freezelist_registry.aleo/block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
+
+        if (current_root != root) {
+            let previous_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+            assert_eq(root, previous_root);
+            let updated_height: u32 = sealance_freezelist_registry.aleo/root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+            assert(updated_height + window > block.height);
+        }
+    }
+
+    // Mints new public tokens to the specified recipient’s balance.
+    // Can only be called by a minter.
+    // Ensures that the new total supply does not exceed the maximum supply.
+    // Updates the recipient’s balance and the total token supply in the token metadata.
+    async transition mint_public(
+        public recipient: address,
+        public amount: u128,
+    ) -> Future {
+        return finalize_mint_public(recipient, amount, self.caller);
+    }
+    async function finalize_mint_public(
+        recipient: address,
+        amount: u128,
+        caller: address
+    ) {
+
+        let role: u16 = address_to_role.get(caller);
+        assert(role & MINTER_ROLE == MINTER_ROLE);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let token = token_info.get(TOKEN_INFO_INDEX);
+        // Check that the token supply + amount <= max_supply
+        let new_supply: u128 = token.supply + amount;
+        assert(new_supply <= token.max_supply);
+
+        // Update the balance
+        let balance = balances.get_or_use(recipient, 0u128);
+        let new_balance = amount + balance;
+        balances.set(recipient, new_balance);
+
+        // Update the token supply
+        let new_metadata: TokenInfo = TokenInfo {
+            name: token.name,
+            symbol: token.symbol,
+            decimals: token.decimals,
+            supply: new_supply,
+            max_supply: token.max_supply,
+        };
+        token_info.set(TOKEN_INFO_INDEX, new_metadata);
+    }
+
+    // Mints new private tokens to the specified recipient.
+    // Can only be called by a minter.
+    // Ensures that the new total supply does not exceed the maximum supply.
+    // Updates the total token supply in the token metadata.
+    async transition mint_private(
+        recipient: address,
+        public amount: u128,
+        ) -> (ComplianceRecord, Token, Future) {
+        let token: Token = Token {
+            owner: recipient,
+            amount: amount,
+        };
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: INVESTIGATOR_ADDRESS,
+            amount: amount,
+            sender: ZERO_ADDRESS,
+            recipient: recipient,
+        };
+        
+        return (compliance_record, token, finalize_mint_private(amount, self.caller));
+    }
+
+    async function finalize_mint_private(
+        amount: u128,
+        caller: address,
+    ) {
+        let role: u16 = address_to_role.get(caller);
+        assert(role & MINTER_ROLE == MINTER_ROLE);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let token = token_info.get(TOKEN_INFO_INDEX);
+
+        // Check that the token supply + amount <= max_supply
+        let new_supply: u128 = token.supply + amount;
+        assert(new_supply <= token.max_supply);
+
+        // Update the token supply
+        let new_metadata: TokenInfo = TokenInfo {
+            name: token.name,
+            symbol: token.symbol,
+            decimals: token.decimals,
+            supply: new_supply,
+            max_supply: token.max_supply,
+        };
+        token_info.set(TOKEN_INFO_INDEX, new_metadata);
+    }
+
+    // Burns public tokens from the specified owner’s balance.
+    // Can only be called by a burner.
+    // Decreases the owner’s balance and reduces the total token supply in the token metadata.
+    async transition burn_public(
+        public owner: address,
+        public amount: u128
+    ) -> Future {
+        return finalize_burn_public(owner, amount, self.caller);
+    }
+
+    async function finalize_burn_public(
+        owner: address,
+        amount: u128,
+        caller: address,
+    ) {
+        let role: u16 = address_to_role.get(caller);
+        assert(role & BURNER_ROLE == BURNER_ROLE);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        // Update the balance
+        let balance = balances.get(owner);
+        let new_balance = balance - amount;
+        balances.set(owner, new_balance);
+
+        let token = token_info.get(TOKEN_INFO_INDEX);
+
+        let new_metadata: TokenInfo = TokenInfo {
+            name: token.name,
+            symbol: token.symbol,
+            decimals: token.decimals,
+            supply: token.supply - amount, // underflow will be caught by the VM
+            max_supply: token.max_supply,
+        };
+        token_info.set(TOKEN_INFO_INDEX, new_metadata);
+    }
+
+    // Burns tokens from a private record (non-public asset).
+    // Can only be called by a burner.
+    // Reduces the amount in the provided private record and decreases the total token supply in the token metadata.
+    async transition burn_private(
+        input_record: Token,
+        public amount: u128
+    ) -> (ComplianceRecord, Token, Future) {
+        let output_record: Token = Token {
+            owner: input_record.owner,
+            amount: input_record.amount - amount
+        };
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: INVESTIGATOR_ADDRESS,
+            amount: amount,
+            sender: input_record.owner,
+            recipient: ZERO_ADDRESS,
+        };
+
+        return (compliance_record, output_record, finalize_burn_private(amount, self.caller));
+    }
+    async function finalize_burn_private(
+        amount: u128,
+        caller: address,
+    ) {
+        let role: u16 = address_to_role.get(caller);
+        assert(role & BURNER_ROLE == BURNER_ROLE);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let token = token_info.get(TOKEN_INFO_INDEX);
+
+        // Update the token supply
+        let new_metadata: TokenInfo = TokenInfo {
+            name: token.name,
+            symbol: token.symbol,
+            decimals: token.decimals,
+            supply: token.supply - amount, // underflow will be caught by the VM
+            max_supply: token.max_supply,
+        };
+        token_info.set(TOKEN_INFO_INDEX, new_metadata);
+    }
+
+    // -------------------------
+    // Called by token owners/DeFi contracts
+    // -------------------------
+
+    // Transfers public tokens from the caller to the recipient.
+    // Both sender and recipient must not be frozen in the freeze list.
+    async transition transfer_public(
+        public recipient: address,
+        public amount: u128
+    ) -> Future {
+        return finalize_transfer_public(recipient, amount, self.caller);
+    }
+
+    async function finalize_transfer_public(
+        recipient: address,
+        amount: u128,
+        sender: address
+    ) {
+        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
+        assert_eq(is_sender_frozen, false);
+        let is_recipient_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(recipient, false);
+        assert_eq(is_recipient_frozen, false);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let sender_balance = balances.get(sender);
+        balances.set(sender, sender_balance - amount);
+
+        let recipient_balance = balances.get_or_use(recipient, 0u128);
+        balances.set(recipient, recipient_balance + amount);
+    }
+
+    // Transfers public tokens from the signer to the recipient.
+    // Both sender and recipient must not be frozen in the freeze list.
+    async transition transfer_public_as_signer(
+        public recipient: address,
+        public amount: u128
+    ) -> Future {
+        return f_transfer_public_as_signer(recipient, amount, self.signer);
+    }
+
+    async function f_transfer_public_as_signer(
+        recipient: address,
+        amount: u128,
+        sender: address
+    ) {
+        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
+        assert_eq(is_sender_frozen, false);
+        let is_recipient_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(recipient, false);
+        assert_eq(is_recipient_frozen, false);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let sender_balance = balances.get(sender);
+        balances.set(sender, sender_balance - amount);
+
+        let recipient_balance = balances.get_or_use(recipient, 0u128);
+        balances.set(recipient, recipient_balance + amount);
+    }
+
+    // Approves a spender to transfer the caller’s public assets up to a specified amount.
+    // Increases the existing allowance if one is already set, otherwise creates a new allowance.
+    // The allowance is stored using a hash of the owner–spender pair as the key.
+    async transition approve_public(
+        public spender: address,
+        public amount: u128
+    ) -> Future {
+        let allowance: TokenAllowance = TokenAllowance {
+            account: self.caller,
+            spender: spender
+        };
+        let allowance_key: field = BHP256::hash_to_field(allowance);
+
+        return finalize_approve_public(amount, allowance_key);
+    }
+
+    async function finalize_approve_public(
+        amount: u128,
+        allowance_key: field
+    ) {
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let current_allowance: u128 = allowances.get_or_use(allowance_key, 0u128);
+        // Increase or create the allowance amount
+        allowances.set(allowance_key, current_allowance + amount);
+    }
+
+    // Reduces a spender’s allowance to transfer the caller’s public assets by a specified amount.
+    // Decreases the existing allowance stored under the hash of the owner–spender pair.
+    // If the reduction exceeds the current allowance, the VM will catch the underflow.
+    async transition unapprove_public(
+        public spender: address,
+        public amount: u128
+    ) -> Future {
+        let allowance: TokenAllowance = TokenAllowance {
+            account: self.caller,
+            spender: spender
+        };
+        let allowance_key: field = BHP256::hash_to_field(allowance);
+
+        return finalize_unapprove_public(amount, allowance_key);
+    }
+    async function finalize_unapprove_public(
+        amount: u128,
+        allowance_key: field
+    ) {
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let current_allowance: u128 = allowances.get(allowance_key);
+        // Decrease the allowance amount
+        allowances.set(allowance_key, current_allowance - amount);
+    }
+
+    // Transfers public tokens from the owner to the recipient.
+    // Can be called by any spender with sufficient allowance from the owner.
+    // Decreases the spender’s allowance by the transferred amount.
+    // Both sender and recipient must not be frozen in the freeze list.
+    async transition transfer_from_public(
+        public owner: address,
+        public recipient: address,
+        public amount: u128
+    ) -> Future {
+        let allowance: TokenAllowance = TokenAllowance {
+            account: owner,
+            spender: self.caller,
+        };
+        let allowance_key: field = BHP256::hash_to_field(allowance);
+
+        return finalize_transfer_from_public(owner, recipient, amount, allowance_key);
+    }
+
+    async function finalize_transfer_from_public(
+        sender: address,
+        recipient: address,
+        amount: u128,
+        allowance_key: field
+    ) {
+        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
+        assert_eq(is_sender_frozen, false);
+        let is_recipient_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(recipient, false);
+        assert_eq(is_recipient_frozen, false);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        // Check that the spender is authorized to spend the amount
+        let current_allowance: u128 = allowances.get(allowance_key);
+        // Decrease the allowance by the amount being spent
+        allowances.set(allowance_key, current_allowance - amount);
+
+        let sender_balance = balances.get(sender);
+        balances.set(sender, sender_balance - amount);
+
+        let recipient_balance = balances.get_or_use(recipient, 0u128);
+        balances.set(recipient, recipient_balance + amount);
+    }
+
+    // Transfers public tokens from the caller to a recipient as a private token.
+    // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
+    // The sender must not be frozen in the freeze list.
+    async transition transfer_public_to_private(
+        recipient: address,
+        public amount: u128,
+    ) -> (ComplianceRecord, Token, Future) {
+        let token: Token = Token {
+            owner: recipient,
+            amount: amount
+        };
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: INVESTIGATOR_ADDRESS,
+            amount: amount,
+            sender: self.caller,
+            recipient: recipient,
+        };
+
+        return (compliance_record, token, f_transfer_public_to_private(amount, self.caller));
+    }
+
+    async function f_transfer_public_to_private(
+        amount: u128,
+        sender: address,
+    ) {
+        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
+        assert_eq(is_sender_frozen, false);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let sender_balance = balances.get(sender);
+        balances.set(sender, sender_balance - amount);
+    }
+
+    // Transfers public tokens from an owner to a recipient as a private token.
+    // Can be called by any spender with sufficient allowance from the owner.
+    // Decreases the spender’s allowance by the transferred amount.
+    // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
+    // The sender must not be frozen in the freeze list.
+    async transition transfer_from_public_to_private(
+        public owner: address,
+        recipient: address,
+        public amount: u128,
+    ) -> (ComplianceRecord, Token, Future) {
+
+        let token: Token = Token {
+            owner: recipient,
+            amount: amount
+        };
+
+        let allowance: TokenAllowance = TokenAllowance {
+            account: owner,
+            spender: self.caller,
+        };
+        let allowance_key: field = BHP256::hash_to_field(allowance);
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: INVESTIGATOR_ADDRESS,
+            amount: amount,
+            sender: owner,
+            recipient: recipient,
+        };
+
+        return (compliance_record, token, f_transfer_from_public_to_priv(owner, amount, allowance_key));
+    }
+
+    async function f_transfer_from_public_to_priv(
+        sender: address,
+        amount: u128,
+        allowance_key: field,
+    ) {
+        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
+        assert_eq(is_sender_frozen, false);
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        // Check that the spender is authorized to spend the amount
+        let current_allowance: u128 = allowances.get(allowance_key);
+        // Decrease the allowance by the amount being spent
+        allowances.set(allowance_key, current_allowance - amount);
+
+        let sender_balance = balances.get(sender);
+        balances.set(sender, sender_balance - amount);
+    }
+
+    // Transfers private tokens from the record owner to a recipient.
+    // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
+    // The sender must not be frozen in the freeze list.
+    // The sender's privacy is preserved by proving non-inclusion in the freeze list Merkle tree.
+    async transition transfer_private(
+        recipient: address,
+        amount: u128,
+        input_record: Token,
+        sender_merkle_proofs: [MerkleProof;2],
+    ) -> (ComplianceRecord, Token, Token, Future) {
+        let sender_root: field = verify_non_inclusion(input_record.owner, sender_merkle_proofs);
+
+        let updated_record: Token = Token {
+            owner: input_record.owner,
+            amount: input_record.amount - amount
+        };
+
+        let transfer_record: Token = Token {
+            owner: recipient,
+            amount: amount
+        };
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: INVESTIGATOR_ADDRESS,
+            amount: amount,
+            sender: input_record.owner,
+            recipient: recipient,
+        };
+
+        return (compliance_record, updated_record, transfer_record, f_transfer_private(sender_root));
+    }
+
+    async function f_transfer_private(root: field) {
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let current_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+        let window: u32 = sealance_freezelist_registry.aleo/block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
+
+        if (current_root != root) {
+            let previous_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+            assert_eq(root, previous_root);
+            let updated_height: u32 = sealance_freezelist_registry.aleo/root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+            assert(updated_height + window > block.height);
+        }
+    }
+
+    // Transfers private tokens from the record owner to a recipient as a public tokens.
+    // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
+    // A Credentials record is emitted for the sender
+    // Both sender and recipient must not be frozen in the freeze list.
+    // The sender's privacy is preserved by proving non-inclusion in the freeze list Merkle tree.
+    async transition transfer_private_to_public(
+        public recipient: address,
+        public amount: u128,
+        input_record: Token,
+        sender_merkle_proofs: [MerkleProof; 2],
+    ) -> (ComplianceRecord, Token, Future) {
+        let root: field = verify_non_inclusion(input_record.owner, sender_merkle_proofs);
+
+        let updated_record: Token = Token {
+            owner: input_record.owner,
+            amount: input_record.amount - amount
+        };
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: INVESTIGATOR_ADDRESS,
+            amount: amount,
+            sender: input_record.owner,
+            recipient: recipient,
+        };
+
+        return (
+            compliance_record,
+            updated_record,
+            f_transfer_private_to_public(
+                root,
+                recipient,
+                amount
+            )
+        );
+    }
+
+    async function f_transfer_private_to_public(
+        root: field,
+        recipient: address,
+        amount: u128    ) {
+        
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let current_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+        let window: u32 = sealance_freezelist_registry.aleo/block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
+
+        if (current_root != root) {
+            let previous_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+            assert_eq(root, previous_root);
+            let updated_height: u32 = sealance_freezelist_registry.aleo/root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+            assert(updated_height + window > block.height);
+        } 
+
+        let is_recipient_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(recipient, false);
+        assert_eq(is_recipient_frozen, false);
+
+        let recipient_balance = balances.get_or_use(recipient, 0u128);
+        balances.set(recipient, recipient_balance + amount);
+    }
+
+    // Stops or resumes all token transfers.
+    // Can only be called by an address with the PAUSE_ROLE.
+    async transition set_pause_status(pause_status: bool) -> Future {
+        return f_set_pause_status(pause_status, self.caller);
+    }
+
+    async function f_set_pause_status(new_pause_status: bool, caller: address) {
+        let role: u16 = address_to_role.get(caller);
+        assert(role & PAUSE_ROLE == PAUSE_ROLE);
+        
+        pause.set(PAUSE_STATUS_INDEX, new_pause_status);
+    }
+
+
+    transition join(
+        private token_1: Token,
+        private token_2: Token
+    ) -> Token {
+        let new_token: Token = Token {
+            owner: token_1.owner,
+            amount: token_1.amount + token_2.amount
+        };
+
+        return new_token;
+    }
+
+    transition split(
+        private token: Token,
+        private amount: u128
+    ) -> (Token, Token) {
+        let new_token_1: Token = Token {
+            owner: token.owner,
+            amount: amount
+        };
+        let new_token_2: Token = Token {
+            owner: token.owner,
+            amount: token.amount - amount
+        };
+
+        return (new_token_1, new_token_2);
+    }
+
+    // Transfers private tokens from the record owner to a recipient.
+    // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
+    // The sender must not be frozen in the freeze list.
+    // The sender's privacy is preserved by using a Credentials record.
+    async transition transfer_private_with_creds(
+        recipient: address,
+        amount: u128,
+        input_record: Token,
+        credentials: Credentials,
+    ) -> (ComplianceRecord, Token, Token, Credentials, Future) {
+        let updated_record: Token = Token {
+            owner: input_record.owner,
+            amount: input_record.amount - amount
+        };
+
+        let transfer_record: Token = Token {
+            owner: recipient,
+            amount: amount
+        };
+
+        let compliance_record: ComplianceRecord = ComplianceRecord {
+            owner: INVESTIGATOR_ADDRESS,
+            amount: amount,
+            sender: input_record.owner,
+            recipient: recipient,
+        };
+
+        let credentials_record: Credentials = Credentials {
+            owner: credentials.owner,
+            freeze_list_root: credentials.freeze_list_root,
+        };
+
+        return (compliance_record, updated_record, transfer_record, credentials_record, f_transfer_private_credentials(credentials.freeze_list_root));
+    }
+
+    async function f_transfer_private_credentials(root: field) {
+
+        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+        assert_eq(is_paused, false);
+
+        let current_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+        let window: u32 = sealance_freezelist_registry.aleo/block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
+
+        if (current_root != root) {
+            let previous_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+            assert_eq(root, previous_root);
+            let updated_height: u32 = sealance_freezelist_registry.aleo/root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+            assert(updated_height + window > block.height);
+        }
+    }
+
+    // Calculates the hash of two sibling nodes in a Merkle tree.
+    // The order of the siblings depends on the index bit (0 = left, 1 = right).
+    // Uses Poseidon hash to compute the result.
+    inline calculate_hash_for_nodes(sibling1: field, sibling2: field, indexbit: u32) -> field {
+        let poseidon_params: [field; 3] = indexbit == 0u32 ? [0field, sibling1, sibling2] : [0field, sibling2, sibling1];
+        return Poseidon4::hash_to_field(poseidon_params);
+    }
+
+    inline calculate_hash_for_leaves(sibling1: field, sibling2: field, indexbit: u32) -> field {
+        let poseidon_params: [field; 3] = indexbit == 0u32 ? [1field, sibling1, sibling2] : [1field, sibling2, sibling1];
+        return Poseidon4::hash_to_field(poseidon_params);
+    }
+
+    // Calculates the Merkle root and the depth of a Merkle proof path.
+    // Iteratively hashes the sibling path based on the leaf index to reconstruct the root.
+    // Stops when a zero field is encountered in the siblings array, indicating the end of the valid path.
+    // Returns the calculated root and the actual depth reached.
+    inline calculate_root_depth_siblings(merkle_proof: MerkleProof) -> (public field, public u32) {
+        let root: field = calculate_hash_for_leaves(merkle_proof.siblings[0u8], merkle_proof.siblings[1u8],  merkle_proof.leaf_index % 2u32);
+        for i: u32 in 2u32..MAX_TREE_DEPTH + 1u32 {
+            if (merkle_proof.siblings[i] == 0field) {
+                return (root, i - 1u32);
+            }
+            root = calculate_hash_for_nodes(root, merkle_proof.siblings[i], (merkle_proof.leaf_index / (2u32**(i-1u32))) % 2u32);
+        }
+        return (root, MAX_TREE_DEPTH);
+    }
+
+    // Verifies non-inclusion of an address in a Merkle tree sorted in ascending order by address (as field).
+    // Accepts two Merkle proofs representing the neighboring leaves around the missing address.
+    // Returns the common Merkle root if the address is proven to be outside the tree.
+    // If the tree is not sorted correctly, this function may return incorrect results.
+    inline verify_non_inclusion(addr: address, merkle_proofs: [MerkleProof;2]) -> field {
+        let (root1, depth1): (field, u32)= calculate_root_depth_siblings(merkle_proofs[0u32]);
+        let (root2, depth2): (field, u32) = calculate_root_depth_siblings(merkle_proofs[1u32]);
+
+        // Ensure the roots from the merkle proofs are the same
+        assert_eq(root1, root2);
+        // Ensure the depth of the merkle proofs is the same
+        assert_eq(depth1, depth2);
+        
+        let addr_field: field = addr as field;
+        if (merkle_proofs[0u32].leaf_index == merkle_proofs[1u32].leaf_index) {
+            // Ensure that if the address is the most left leaf, it is less than the first sibling
+            if (merkle_proofs[0u32].leaf_index == 0u32) {
+                assert(addr_field < merkle_proofs[0u32].siblings[0u32]);
+            } else {
+                // Ensure that if the address is the most right leaf
+                let last_index_leaf: u32 = 2u32 ** depth1 - 1u32;
+                assert_eq(merkle_proofs[0u32].leaf_index, last_index_leaf);
+                // Ensure that the address is bigger than the first sibling
+                assert(addr_field > merkle_proofs[0u32].siblings[0u32]);
+            }
+        } else {
+            // Ensure the address is in between the provided leaves
+            assert(addr_field > merkle_proofs[0u32].siblings[0u32]);
+            assert(addr_field < merkle_proofs[1u32].siblings[0u32]);
+            // Ensure that the leaf indexes are not greater than the last possible leaf index
+            let last_index_leaf: u32 = 2u32 ** depth1 - 1u32;
+            assert(merkle_proofs[1u32].leaf_index <= last_index_leaf);
+            // Ensure the leaves are adjacent
+            assert_eq(merkle_proofs[0u32].leaf_index + 1u32, merkle_proofs[1u32].leaf_index);
+        }
+        
+        return root1;
+    }
+}

--- a/programs/amm/stable_token_2.leo
+++ b/programs/amm/stable_token_2.leo
@@ -1,22 +1,112 @@
 import sealance_freezelist_registry.aleo;
 import multisig_core.aleo;
 
+struct MerkleProof {
+    siblings: [field; 16],
+    leaf_index: u32
+}
+
+struct ChecksumEdition {
+    checksum: [u8; 32],
+    edition: u16,
+}
+
+struct TokenInfo {
+    name: u128, // ASCII text represented in bits, and the u128 value of the bitstring
+    symbol: u128, // ASCII text represented in bits, and the u128 value of the bitstring
+    decimals: u8,
+    supply: u128,
+    max_supply: u128,
+}
+
+struct TokenAllowance {
+    account: address,
+    spender: address,
+}
+
+// Calculates the hash of two sibling nodes in a Merkle tree.
+// The order of the siblings depends on the index bit (0 = left, 1 = right).
+// Uses Poseidon hash to compute the result.
+fn calculate_hash_for_nodes(sibling1: field, sibling2: field, indexbit: u32) -> field {
+    let poseidon_params: [field; 3] = indexbit == 0u32 ? [0field, sibling1, sibling2] : [0field, sibling2, sibling1];
+    return Poseidon4::hash_to_field(poseidon_params);
+}
+
+fn calculate_hash_for_leaves(sibling1: field, sibling2: field, indexbit: u32) -> field {
+    let poseidon_params: [field; 3] = indexbit == 0u32 ? [1field, sibling1, sibling2] : [1field, sibling2, sibling1];
+    return Poseidon4::hash_to_field(poseidon_params);
+}
+
+// Calculates the Merkle root and the depth of a Merkle proof path.
+// Iteratively hashes the sibling path based on the leaf index to reconstruct the root.
+// Stops when a zero field is encountered in the siblings array, indicating the end of the valid path.
+// Returns the calculated root and the actual depth reached.
+fn calculate_root_depth_siblings(merkle_proof: MerkleProof) -> (public field, public u32) {
+    let root: field = calculate_hash_for_leaves(merkle_proof.siblings[0u8], merkle_proof.siblings[1u8],  merkle_proof.leaf_index % 2u32);
+    for i: u32 in 2u32..MAX_TREE_DEPTH + 1u32 {
+        if (merkle_proof.siblings[i] == 0field) {
+            return (root, i - 1u32);
+        }
+        root = calculate_hash_for_nodes(root, merkle_proof.siblings[i], (merkle_proof.leaf_index / (2u32**(i-1u32))) % 2u32);
+    }
+    return (root, MAX_TREE_DEPTH);
+}
+
+// Verifies non-inclusion of an address in a Merkle tree sorted in ascending order by address (as field).
+// Accepts two Merkle proofs representing the neighboring leaves around the missing address.
+// Returns the common Merkle root if the address is proven to be outside the tree.
+// If the tree is not sorted correctly, this function may return incorrect results.
+fn verify_non_inclusion(addr: address, merkle_proofs: [MerkleProof;2]) -> field {
+    let (root1, depth1): (field, u32)= calculate_root_depth_siblings(merkle_proofs[0u32]);
+    let (root2, depth2): (field, u32) = calculate_root_depth_siblings(merkle_proofs[1u32]);
+
+    // Ensure the roots from the merkle proofs are the same
+    assert_eq(root1, root2);
+    // Ensure the depth of the merkle proofs is the same
+    assert_eq(depth1, depth2);
+
+    let addr_field: field = addr as field;
+    if (merkle_proofs[0u32].leaf_index == merkle_proofs[1u32].leaf_index) {
+        // Ensure that if the address is the most left leaf, it is less than the first sibling
+        if (merkle_proofs[0u32].leaf_index == 0u32) {
+            assert(addr_field < merkle_proofs[0u32].siblings[0u32]);
+        } else {
+            // Ensure that if the address is the most right leaf
+            let last_index_leaf: u32 = 2u32 ** depth1 - 1u32;
+            assert_eq(merkle_proofs[0u32].leaf_index, last_index_leaf);
+            // Ensure that the address is bigger than the first sibling
+            assert(addr_field > merkle_proofs[0u32].siblings[0u32]);
+        }
+    } else {
+        // Ensure the address is in between the provided leaves
+        assert(addr_field > merkle_proofs[0u32].siblings[0u32]);
+        assert(addr_field < merkle_proofs[1u32].siblings[0u32]);
+        // Ensure that the leaf indexes are not greater than the last possible leaf index
+        let last_index_leaf: u32 = 2u32 ** depth1 - 1u32;
+        assert(merkle_proofs[1u32].leaf_index <= last_index_leaf);
+        // Ensure the leaves are adjacent
+        assert_eq(merkle_proofs[0u32].leaf_index + 1u32, merkle_proofs[1u32].leaf_index);
+    }
+
+    return root1;
+}
+
 program stable_token_2.aleo {
     @custom
-    async constructor() {
+    constructor() {
         // Only require multisig for upgrades - initial deployment has no checks.
         if self.edition > 0u16 {
             let signing_op_id = BHP256::hash_to_field(ChecksumEdition { checksum: self.checksum, edition: self.edition });
 
-            let wallet_signing_op_id_hash = BHP256::hash_to_field(multisig_core.aleo/WalletSigningOpId { wallet_id: self.address, signing_op_id: signing_op_id });
-            let signing_complete = multisig_core.aleo/completed_signing_ops.contains(wallet_signing_op_id_hash);
+            let wallet_signing_op_id_hash = BHP256::hash_to_field(multisig_core.aleo::WalletSigningOpId { wallet_id: self.address, signing_op_id: signing_op_id });
+            let signing_complete = multisig_core.aleo::completed_signing_ops.contains(wallet_signing_op_id_hash);
             assert(signing_complete);
         }
     }
 
     // A helper for calculating a signing_op_id from the program's checksum and edition.
     // By deriving the signing_op_id from both we ensure that downgrades cannot take place.
-    transition get_signing_op_id_for_deploy(checksum: [u8; 32], edition: u16) -> field {
+    fn get_signing_op_id_for_deploy(checksum: [u8; 32], edition: u16) -> field {
         return BHP256::hash_to_field(ChecksumEdition { checksum: checksum, edition: edition });
     }
 
@@ -38,29 +128,6 @@ program stable_token_2.aleo {
         freeze_list_root: field,
     }
 
-    struct MerkleProof {
-        siblings: [field; 16],
-        leaf_index: u32
-    }
-
-    struct ChecksumEdition {
-        checksum: [u8; 32],
-        edition: u16,
-    }
-
-    struct TokenInfo {
-        name: u128, // ASCII text represented in bits, and the u128 value of the bitstring
-        symbol: u128, // ASCII text represented in bits, and the u128 value of the bitstring
-        decimals: u8,
-        supply: u128,
-        max_supply: u128,
-    }
-
-    struct TokenAllowance {
-        account: address,
-        spender: address,
-    }
-    
     const TOKEN_INFO_INDEX: bool = true;
     // token specs
     mapping token_info: bool => TokenInfo;
@@ -101,76 +168,61 @@ program stable_token_2.aleo {
 
     // Updates the address assigned to a given role.
     // Can only be called by the current role manager.
-    async transition update_role(public new_address: address, role: u16) -> Future {
-        return f_update_role(new_address, self.caller, role);
-    }
-    async function f_update_role(new_address: address, caller: address, new_role: u16) {
-        let current_role: u16 = address_to_role.get(caller);
-        assert(current_role & MANAGER_ROLE == MANAGER_ROLE);
-        
-        if (caller == new_address) { 
-            assert(new_role & MANAGER_ROLE == MANAGER_ROLE); 
-        }
+    fn update_role(public new_address: address, role: u16) -> Final {
+        let caller: address = self.caller;
+        return final {
+            let current_role: u16 = address_to_role.get(caller);
+            assert(current_role & MANAGER_ROLE == MANAGER_ROLE);
 
-        address_to_role.set(new_address, new_role);
+            if (caller == new_address) {
+                assert(role & MANAGER_ROLE == MANAGER_ROLE);
+            }
 
+            address_to_role.set(new_address, role);
+        };
     }
 
     // Initializes the freeze list, token specifications, the admin and the investigator.
-    // Can be called only once and only by the INITIAL_ADMIN    
+    // Can be called only once and only by the INITIAL_ADMIN
     // Sets the token metadata (name, symbol, decimals, max supply).
     // Sets the block height window, the initial empty Merkle root,
     // and initialize the freeze_list_last_index, freeze_list, and freeze_list_index with a ZERO_ADDRESS placeholder.
-    async transition initialize(
+    fn initialize(
         public name: u128,
         public symbol: u128,
         public decimals: u8,
         public max_supply: u128,
         public admin: address,
-    ) -> Future {
-        return finalize_initialize(
-            name,
-            symbol,
-            decimals,
-            max_supply,
-            admin,
-            self.caller,
-        );
-    }
-    async function finalize_initialize(
-        name: u128,
-        symbol: u128,
-        decimals: u8,
-        max_supply: u128,
-        admin: address, 
-        caller: address,
-    ) {
-        // Check if the token has already been initialized
-        let already_initialized: bool = token_info.contains(TOKEN_INFO_INDEX);
-        assert_eq(already_initialized, false);
-        
-        // Only the INITIAL_CONFIGURATION_ADDRESS can initialize the contract
-        assert_eq(caller, DEPLOYER_ADDRESS);
-        
-        address_to_role.set(admin, MANAGER_ROLE);
+    ) -> Final {
+        let caller: address = self.caller;
+        return final {
+            // Check if the token has already been initialized
+            let already_initialized: bool = token_info.contains(TOKEN_INFO_INDEX);
+            assert_eq(already_initialized, false);
 
-        let token: TokenInfo = TokenInfo {
-            name: name,
-            symbol: symbol,
-            decimals: decimals,
-            supply: 0u128, // placeholder value; not used
-            max_supply: max_supply
+            // Only the INITIAL_CONFIGURATION_ADDRESS can initialize the contract
+            assert_eq(caller, DEPLOYER_ADDRESS);
+
+            address_to_role.set(admin, MANAGER_ROLE);
+
+            let token: TokenInfo = TokenInfo {
+                name: name,
+                symbol: symbol,
+                decimals: decimals,
+                supply: 0u128, // placeholder value; not used
+                max_supply: max_supply
+            };
+
+            token_info.set(TOKEN_INFO_INDEX, token);
+
+            pause.set(PAUSE_STATUS_INDEX, false);
         };
-
-        token_info.set(TOKEN_INFO_INDEX, token);
-
-        pause.set(PAUSE_STATUS_INDEX, false);
     }
 
     // Generates a Credential record for the signer.
     // Allows future private transfers without needing to re-prove non-inclusion in the freeze list.
     // The signer's privacy is preserved by proving non-inclusion in the freeze list Merkle tree.
-    async transition get_credentials(sender_merkle_proofs: [MerkleProof;2]) -> (Credentials, Future) {
+    fn get_credentials(sender_merkle_proofs: [MerkleProof;2]) -> (Credentials, Final) {
         let root: field = verify_non_inclusion(self.signer, sender_merkle_proofs);
 
         let credentials_record: Credentials = Credentials {
@@ -178,71 +230,65 @@ program stable_token_2.aleo {
             freeze_list_root: root,
         };
 
-        return (credentials_record, f_get_credentials(root));
-    }
-    async function f_get_credentials(root: field) {
-        let current_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
-        let window: u32 = sealance_freezelist_registry.aleo/block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
+        return (credentials_record, final {
+            let current_root: field = sealance_freezelist_registry.aleo::freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+            let window: u32 = sealance_freezelist_registry.aleo::block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
 
-        if (current_root != root) {
-            let previous_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
-            assert_eq(root, previous_root);
-            let updated_height: u32 = sealance_freezelist_registry.aleo/root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
-            assert(updated_height + window > block.height);
-        }
+            if (current_root != root) {
+                let previous_root: field = sealance_freezelist_registry.aleo::freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+                assert_eq(root, previous_root);
+                let updated_height: u32 = sealance_freezelist_registry.aleo::root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+                assert(updated_height + window > block.height);
+            }
+        });
     }
 
-    // Mints new public tokens to the specified recipient’s balance.
+    // Mints new public tokens to the specified recipient's balance.
     // Can only be called by a minter.
     // Ensures that the new total supply does not exceed the maximum supply.
-    // Updates the recipient’s balance and the total token supply in the token metadata.
-    async transition mint_public(
+    // Updates the recipient's balance and the total token supply in the token metadata.
+    fn mint_public(
         public recipient: address,
         public amount: u128,
-    ) -> Future {
-        return finalize_mint_public(recipient, amount, self.caller);
-    }
-    async function finalize_mint_public(
-        recipient: address,
-        amount: u128,
-        caller: address
-    ) {
+    ) -> Final {
+        let caller: address = self.caller;
+        return final {
+            let role: u16 = address_to_role.get(caller);
+            assert(role & MINTER_ROLE == MINTER_ROLE);
 
-        let role: u16 = address_to_role.get(caller);
-        assert(role & MINTER_ROLE == MINTER_ROLE);
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
+            let token = token_info.get(TOKEN_INFO_INDEX);
+            // Check that the token supply + amount <= max_supply
+            let new_supply: u128 = token.supply + amount;
+            assert(new_supply <= token.max_supply);
 
-        let token = token_info.get(TOKEN_INFO_INDEX);
-        // Check that the token supply + amount <= max_supply
-        let new_supply: u128 = token.supply + amount;
-        assert(new_supply <= token.max_supply);
+            // Update the balance
+            let balance = balances.get_or_use(recipient, 0u128);
+            let new_balance = amount + balance;
+            balances.set(recipient, new_balance);
 
-        // Update the balance
-        let balance = balances.get_or_use(recipient, 0u128);
-        let new_balance = amount + balance;
-        balances.set(recipient, new_balance);
-
-        // Update the token supply
-        let new_metadata: TokenInfo = TokenInfo {
-            name: token.name,
-            symbol: token.symbol,
-            decimals: token.decimals,
-            supply: new_supply,
-            max_supply: token.max_supply,
+            // Update the token supply
+            let new_metadata: TokenInfo = TokenInfo {
+                name: token.name,
+                symbol: token.symbol,
+                decimals: token.decimals,
+                supply: new_supply,
+                max_supply: token.max_supply,
+            };
+            token_info.set(TOKEN_INFO_INDEX, new_metadata);
         };
-        token_info.set(TOKEN_INFO_INDEX, new_metadata);
     }
 
     // Mints new private tokens to the specified recipient.
     // Can only be called by a minter.
     // Ensures that the new total supply does not exceed the maximum supply.
     // Updates the total token supply in the token metadata.
-    async transition mint_private(
+    fn mint_private(
         recipient: address,
         public amount: u128,
-        ) -> (ComplianceRecord, Token, Future) {
+        ) -> (ComplianceRecord, Token, Final) {
         let token: Token = Token {
             owner: recipient,
             amount: amount,
@@ -254,82 +300,73 @@ program stable_token_2.aleo {
             sender: ZERO_ADDRESS,
             recipient: recipient,
         };
-        
-        return (compliance_record, token, finalize_mint_private(amount, self.caller));
+
+        let caller: address = self.caller;
+        return (compliance_record, token, final {
+            let role: u16 = address_to_role.get(caller);
+            assert(role & MINTER_ROLE == MINTER_ROLE);
+
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
+
+            let token_metadata = token_info.get(TOKEN_INFO_INDEX);
+
+            // Check that the token supply + amount <= max_supply
+            let new_supply: u128 = token_metadata.supply + amount;
+            assert(new_supply <= token_metadata.max_supply);
+
+            // Update the token supply
+            let new_metadata: TokenInfo = TokenInfo {
+                name: token_metadata.name,
+                symbol: token_metadata.symbol,
+                decimals: token_metadata.decimals,
+                supply: new_supply,
+                max_supply: token_metadata.max_supply,
+            };
+            token_info.set(TOKEN_INFO_INDEX, new_metadata);
+        });
     }
 
-    async function finalize_mint_private(
-        amount: u128,
-        caller: address,
-    ) {
-        let role: u16 = address_to_role.get(caller);
-        assert(role & MINTER_ROLE == MINTER_ROLE);
-
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
-
-        let token = token_info.get(TOKEN_INFO_INDEX);
-
-        // Check that the token supply + amount <= max_supply
-        let new_supply: u128 = token.supply + amount;
-        assert(new_supply <= token.max_supply);
-
-        // Update the token supply
-        let new_metadata: TokenInfo = TokenInfo {
-            name: token.name,
-            symbol: token.symbol,
-            decimals: token.decimals,
-            supply: new_supply,
-            max_supply: token.max_supply,
-        };
-        token_info.set(TOKEN_INFO_INDEX, new_metadata);
-    }
-
-    // Burns public tokens from the specified owner’s balance.
+    // Burns public tokens from the specified owner's balance.
     // Can only be called by a burner.
-    // Decreases the owner’s balance and reduces the total token supply in the token metadata.
-    async transition burn_public(
+    // Decreases the owner's balance and reduces the total token supply in the token metadata.
+    fn burn_public(
         public owner: address,
         public amount: u128
-    ) -> Future {
-        return finalize_burn_public(owner, amount, self.caller);
-    }
+    ) -> Final {
+        let caller: address = self.caller;
+        return final {
+            let role: u16 = address_to_role.get(caller);
+            assert(role & BURNER_ROLE == BURNER_ROLE);
 
-    async function finalize_burn_public(
-        owner: address,
-        amount: u128,
-        caller: address,
-    ) {
-        let role: u16 = address_to_role.get(caller);
-        assert(role & BURNER_ROLE == BURNER_ROLE);
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
+            // Update the balance
+            let balance = balances.get(owner);
+            let new_balance = balance - amount;
+            balances.set(owner, new_balance);
 
-        // Update the balance
-        let balance = balances.get(owner);
-        let new_balance = balance - amount;
-        balances.set(owner, new_balance);
+            let token = token_info.get(TOKEN_INFO_INDEX);
 
-        let token = token_info.get(TOKEN_INFO_INDEX);
-
-        let new_metadata: TokenInfo = TokenInfo {
-            name: token.name,
-            symbol: token.symbol,
-            decimals: token.decimals,
-            supply: token.supply - amount, // underflow will be caught by the VM
-            max_supply: token.max_supply,
+            let new_metadata: TokenInfo = TokenInfo {
+                name: token.name,
+                symbol: token.symbol,
+                decimals: token.decimals,
+                supply: token.supply - amount, // underflow will be caught by the VM
+                max_supply: token.max_supply,
+            };
+            token_info.set(TOKEN_INFO_INDEX, new_metadata);
         };
-        token_info.set(TOKEN_INFO_INDEX, new_metadata);
     }
 
     // Burns tokens from a private record (non-public asset).
     // Can only be called by a burner.
     // Reduces the amount in the provided private record and decreases the total token supply in the token metadata.
-    async transition burn_private(
+    fn burn_private(
         input_record: Token,
         public amount: u128
-    ) -> (ComplianceRecord, Token, Future) {
+    ) -> (ComplianceRecord, Token, Final) {
         let output_record: Token = Token {
             owner: input_record.owner,
             amount: input_record.amount - amount
@@ -342,29 +379,26 @@ program stable_token_2.aleo {
             recipient: ZERO_ADDRESS,
         };
 
-        return (compliance_record, output_record, finalize_burn_private(amount, self.caller));
-    }
-    async function finalize_burn_private(
-        amount: u128,
-        caller: address,
-    ) {
-        let role: u16 = address_to_role.get(caller);
-        assert(role & BURNER_ROLE == BURNER_ROLE);
+        let caller: address = self.caller;
+        return (compliance_record, output_record, final {
+            let role: u16 = address_to_role.get(caller);
+            assert(role & BURNER_ROLE == BURNER_ROLE);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-        let token = token_info.get(TOKEN_INFO_INDEX);
+            let token = token_info.get(TOKEN_INFO_INDEX);
 
-        // Update the token supply
-        let new_metadata: TokenInfo = TokenInfo {
-            name: token.name,
-            symbol: token.symbol,
-            decimals: token.decimals,
-            supply: token.supply - amount, // underflow will be caught by the VM
-            max_supply: token.max_supply,
-        };
-        token_info.set(TOKEN_INFO_INDEX, new_metadata);
+            // Update the token supply
+            let new_metadata: TokenInfo = TokenInfo {
+                name: token.name,
+                symbol: token.symbol,
+                decimals: token.decimals,
+                supply: token.supply - amount, // underflow will be caught by the VM
+                max_supply: token.max_supply,
+            };
+            token_info.set(TOKEN_INFO_INDEX, new_metadata);
+        });
     }
 
     // -------------------------
@@ -373,170 +407,142 @@ program stable_token_2.aleo {
 
     // Transfers public tokens from the caller to the recipient.
     // Both sender and recipient must not be frozen in the freeze list.
-    async transition transfer_public(
+    fn transfer_public(
         public recipient: address,
         public amount: u128
-    ) -> Future {
-        return finalize_transfer_public(recipient, amount, self.caller);
-    }
+    ) -> Final {
+        let caller: address = self.caller;
+        return final {
+            let is_sender_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(caller, false);
+            assert_eq(is_sender_frozen, false);
+            let is_recipient_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(recipient, false);
+            assert_eq(is_recipient_frozen, false);
 
-    async function finalize_transfer_public(
-        recipient: address,
-        amount: u128,
-        sender: address
-    ) {
-        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
-        assert_eq(is_sender_frozen, false);
-        let is_recipient_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(recipient, false);
-        assert_eq(is_recipient_frozen, false);
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
+            let sender_balance = balances.get(caller);
+            balances.set(caller, sender_balance - amount);
 
-        let sender_balance = balances.get(sender);
-        balances.set(sender, sender_balance - amount);
-
-        let recipient_balance = balances.get_or_use(recipient, 0u128);
-        balances.set(recipient, recipient_balance + amount);
+            let recipient_balance = balances.get_or_use(recipient, 0u128);
+            balances.set(recipient, recipient_balance + amount);
+        };
     }
 
     // Transfers public tokens from the signer to the recipient.
     // Both sender and recipient must not be frozen in the freeze list.
-    async transition transfer_public_as_signer(
+    fn transfer_public_as_signer(
         public recipient: address,
         public amount: u128
-    ) -> Future {
-        return f_transfer_public_as_signer(recipient, amount, self.signer);
+    ) -> Final {
+        let signer: address = self.signer;
+        return final {
+            let is_sender_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(signer, false);
+            assert_eq(is_sender_frozen, false);
+            let is_recipient_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(recipient, false);
+            assert_eq(is_recipient_frozen, false);
+
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
+
+            let sender_balance = balances.get(signer);
+            balances.set(signer, sender_balance - amount);
+
+            let recipient_balance = balances.get_or_use(recipient, 0u128);
+            balances.set(recipient, recipient_balance + amount);
+        };
     }
 
-    async function f_transfer_public_as_signer(
-        recipient: address,
-        amount: u128,
-        sender: address
-    ) {
-        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
-        assert_eq(is_sender_frozen, false);
-        let is_recipient_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(recipient, false);
-        assert_eq(is_recipient_frozen, false);
-
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
-
-        let sender_balance = balances.get(sender);
-        balances.set(sender, sender_balance - amount);
-
-        let recipient_balance = balances.get_or_use(recipient, 0u128);
-        balances.set(recipient, recipient_balance + amount);
-    }
-
-    // Approves a spender to transfer the caller’s public assets up to a specified amount.
+    // Approves a spender to transfer the caller's public assets up to a specified amount.
     // Increases the existing allowance if one is already set, otherwise creates a new allowance.
-    // The allowance is stored using a hash of the owner–spender pair as the key.
-    async transition approve_public(
+    // The allowance is stored using a hash of the owner-spender pair as the key.
+    fn approve_public(
         public spender: address,
         public amount: u128
-    ) -> Future {
+    ) -> Final {
         let allowance: TokenAllowance = TokenAllowance {
             account: self.caller,
             spender: spender
         };
         let allowance_key: field = BHP256::hash_to_field(allowance);
 
-        return finalize_approve_public(amount, allowance_key);
+        return final {
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
+
+            let current_allowance: u128 = allowances.get_or_use(allowance_key, 0u128);
+            // Increase or create the allowance amount
+            allowances.set(allowance_key, current_allowance + amount);
+        };
     }
 
-    async function finalize_approve_public(
-        amount: u128,
-        allowance_key: field
-    ) {
-
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
-
-        let current_allowance: u128 = allowances.get_or_use(allowance_key, 0u128);
-        // Increase or create the allowance amount
-        allowances.set(allowance_key, current_allowance + amount);
-    }
-
-    // Reduces a spender’s allowance to transfer the caller’s public assets by a specified amount.
-    // Decreases the existing allowance stored under the hash of the owner–spender pair.
+    // Reduces a spender's allowance to transfer the caller's public assets by a specified amount.
+    // Decreases the existing allowance stored under the hash of the owner-spender pair.
     // If the reduction exceeds the current allowance, the VM will catch the underflow.
-    async transition unapprove_public(
+    fn unapprove_public(
         public spender: address,
         public amount: u128
-    ) -> Future {
+    ) -> Final {
         let allowance: TokenAllowance = TokenAllowance {
             account: self.caller,
             spender: spender
         };
         let allowance_key: field = BHP256::hash_to_field(allowance);
 
-        return finalize_unapprove_public(amount, allowance_key);
-    }
-    async function finalize_unapprove_public(
-        amount: u128,
-        allowance_key: field
-    ) {
+        return final {
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
-
-        let current_allowance: u128 = allowances.get(allowance_key);
-        // Decrease the allowance amount
-        allowances.set(allowance_key, current_allowance - amount);
+            let current_allowance: u128 = allowances.get(allowance_key);
+            // Decrease the allowance amount
+            allowances.set(allowance_key, current_allowance - amount);
+        };
     }
 
     // Transfers public tokens from the owner to the recipient.
     // Can be called by any spender with sufficient allowance from the owner.
-    // Decreases the spender’s allowance by the transferred amount.
+    // Decreases the spender's allowance by the transferred amount.
     // Both sender and recipient must not be frozen in the freeze list.
-    async transition transfer_from_public(
+    fn transfer_from_public(
         public owner: address,
         public recipient: address,
         public amount: u128
-    ) -> Future {
+    ) -> Final {
         let allowance: TokenAllowance = TokenAllowance {
             account: owner,
             spender: self.caller,
         };
         let allowance_key: field = BHP256::hash_to_field(allowance);
 
-        return finalize_transfer_from_public(owner, recipient, amount, allowance_key);
-    }
+        return final {
+            let is_sender_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(owner, false);
+            assert_eq(is_sender_frozen, false);
+            let is_recipient_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(recipient, false);
+            assert_eq(is_recipient_frozen, false);
 
-    async function finalize_transfer_from_public(
-        sender: address,
-        recipient: address,
-        amount: u128,
-        allowance_key: field
-    ) {
-        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
-        assert_eq(is_sender_frozen, false);
-        let is_recipient_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(recipient, false);
-        assert_eq(is_recipient_frozen, false);
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
+            // Check that the spender is authorized to spend the amount
+            let current_allowance: u128 = allowances.get(allowance_key);
+            // Decrease the allowance by the amount being spent
+            allowances.set(allowance_key, current_allowance - amount);
 
-        // Check that the spender is authorized to spend the amount
-        let current_allowance: u128 = allowances.get(allowance_key);
-        // Decrease the allowance by the amount being spent
-        allowances.set(allowance_key, current_allowance - amount);
+            let sender_balance = balances.get(owner);
+            balances.set(owner, sender_balance - amount);
 
-        let sender_balance = balances.get(sender);
-        balances.set(sender, sender_balance - amount);
-
-        let recipient_balance = balances.get_or_use(recipient, 0u128);
-        balances.set(recipient, recipient_balance + amount);
+            let recipient_balance = balances.get_or_use(recipient, 0u128);
+            balances.set(recipient, recipient_balance + amount);
+        };
     }
 
     // Transfers public tokens from the caller to a recipient as a private token.
     // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
     // The sender must not be frozen in the freeze list.
-    async transition transfer_public_to_private(
+    fn transfer_public_to_private(
         recipient: address,
         public amount: u128,
-    ) -> (ComplianceRecord, Token, Future) {
+    ) -> (ComplianceRecord, Token, Final) {
         let token: Token = Token {
             owner: recipient,
             amount: amount
@@ -549,33 +555,29 @@ program stable_token_2.aleo {
             recipient: recipient,
         };
 
-        return (compliance_record, token, f_transfer_public_to_private(amount, self.caller));
-    }
+        let caller: address = self.caller;
+        return (compliance_record, token, final {
+            let is_sender_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(caller, false);
+            assert_eq(is_sender_frozen, false);
 
-    async function f_transfer_public_to_private(
-        amount: u128,
-        sender: address,
-    ) {
-        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
-        assert_eq(is_sender_frozen, false);
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
-
-        let sender_balance = balances.get(sender);
-        balances.set(sender, sender_balance - amount);
+            let sender_balance = balances.get(caller);
+            balances.set(caller, sender_balance - amount);
+        });
     }
 
     // Transfers public tokens from an owner to a recipient as a private token.
     // Can be called by any spender with sufficient allowance from the owner.
-    // Decreases the spender’s allowance by the transferred amount.
+    // Decreases the spender's allowance by the transferred amount.
     // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
     // The sender must not be frozen in the freeze list.
-    async transition transfer_from_public_to_private(
+    fn transfer_from_public_to_private(
         public owner: address,
         recipient: address,
         public amount: u128,
-    ) -> (ComplianceRecord, Token, Future) {
+    ) -> (ComplianceRecord, Token, Final) {
 
         let token: Token = Token {
             owner: recipient,
@@ -595,39 +597,33 @@ program stable_token_2.aleo {
             recipient: recipient,
         };
 
-        return (compliance_record, token, f_transfer_from_public_to_priv(owner, amount, allowance_key));
-    }
+        return (compliance_record, token, final {
+            let is_sender_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(owner, false);
+            assert_eq(is_sender_frozen, false);
 
-    async function f_transfer_from_public_to_priv(
-        sender: address,
-        amount: u128,
-        allowance_key: field,
-    ) {
-        let is_sender_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(sender, false);
-        assert_eq(is_sender_frozen, false);
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
+            // Check that the spender is authorized to spend the amount
+            let current_allowance: u128 = allowances.get(allowance_key);
+            // Decrease the allowance by the amount being spent
+            allowances.set(allowance_key, current_allowance - amount);
 
-        // Check that the spender is authorized to spend the amount
-        let current_allowance: u128 = allowances.get(allowance_key);
-        // Decrease the allowance by the amount being spent
-        allowances.set(allowance_key, current_allowance - amount);
-
-        let sender_balance = balances.get(sender);
-        balances.set(sender, sender_balance - amount);
+            let sender_balance = balances.get(owner);
+            balances.set(owner, sender_balance - amount);
+        });
     }
 
     // Transfers private tokens from the record owner to a recipient.
     // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
     // The sender must not be frozen in the freeze list.
     // The sender's privacy is preserved by proving non-inclusion in the freeze list Merkle tree.
-    async transition transfer_private(
+    fn transfer_private(
         recipient: address,
         amount: u128,
         input_record: Token,
         sender_merkle_proofs: [MerkleProof;2],
-    ) -> (ComplianceRecord, Token, Token, Future) {
+    ) -> (ComplianceRecord, Token, Token, Final) {
         let sender_root: field = verify_non_inclusion(input_record.owner, sender_merkle_proofs);
 
         let updated_record: Token = Token {
@@ -647,23 +643,20 @@ program stable_token_2.aleo {
             recipient: recipient,
         };
 
-        return (compliance_record, updated_record, transfer_record, f_transfer_private(sender_root));
-    }
+        return (compliance_record, updated_record, transfer_record, final {
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-    async function f_transfer_private(root: field) {
+            let current_root: field = sealance_freezelist_registry.aleo::freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+            let window: u32 = sealance_freezelist_registry.aleo::block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
-
-        let current_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
-        let window: u32 = sealance_freezelist_registry.aleo/block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
-
-        if (current_root != root) {
-            let previous_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
-            assert_eq(root, previous_root);
-            let updated_height: u32 = sealance_freezelist_registry.aleo/root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
-            assert(updated_height + window > block.height);
-        }
+            if (current_root != sender_root) {
+                let previous_root: field = sealance_freezelist_registry.aleo::freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+                assert_eq(sender_root, previous_root);
+                let updated_height: u32 = sealance_freezelist_registry.aleo::root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+                assert(updated_height + window > block.height);
+            }
+        });
     }
 
     // Transfers private tokens from the record owner to a recipient as a public tokens.
@@ -671,12 +664,12 @@ program stable_token_2.aleo {
     // A Credentials record is emitted for the sender
     // Both sender and recipient must not be frozen in the freeze list.
     // The sender's privacy is preserved by proving non-inclusion in the freeze list Merkle tree.
-    async transition transfer_private_to_public(
+    fn transfer_private_to_public(
         public recipient: address,
         public amount: u128,
         input_record: Token,
         sender_merkle_proofs: [MerkleProof; 2],
-    ) -> (ComplianceRecord, Token, Future) {
+    ) -> (ComplianceRecord, Token, Final) {
         let root: field = verify_non_inclusion(input_record.owner, sender_merkle_proofs);
 
         let updated_record: Token = Token {
@@ -694,54 +687,43 @@ program stable_token_2.aleo {
         return (
             compliance_record,
             updated_record,
-            f_transfer_private_to_public(
-                root,
-                recipient,
-                amount
-            )
+            final {
+                let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+                assert_eq(is_paused, false);
+
+                let current_root: field = sealance_freezelist_registry.aleo::freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+                let window: u32 = sealance_freezelist_registry.aleo::block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
+
+                if (current_root != root) {
+                    let previous_root: field = sealance_freezelist_registry.aleo::freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+                    assert_eq(root, previous_root);
+                    let updated_height: u32 = sealance_freezelist_registry.aleo::root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+                    assert(updated_height + window > block.height);
+                }
+
+                let is_recipient_frozen: bool = sealance_freezelist_registry.aleo::freeze_list.get_or_use(recipient, false);
+                assert_eq(is_recipient_frozen, false);
+
+                let recipient_balance = balances.get_or_use(recipient, 0u128);
+                balances.set(recipient, recipient_balance + amount);
+            }
         );
-    }
-
-    async function f_transfer_private_to_public(
-        root: field,
-        recipient: address,
-        amount: u128    ) {
-        
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
-
-        let current_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
-        let window: u32 = sealance_freezelist_registry.aleo/block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
-
-        if (current_root != root) {
-            let previous_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
-            assert_eq(root, previous_root);
-            let updated_height: u32 = sealance_freezelist_registry.aleo/root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
-            assert(updated_height + window > block.height);
-        } 
-
-        let is_recipient_frozen: bool = sealance_freezelist_registry.aleo/freeze_list.get_or_use(recipient, false);
-        assert_eq(is_recipient_frozen, false);
-
-        let recipient_balance = balances.get_or_use(recipient, 0u128);
-        balances.set(recipient, recipient_balance + amount);
     }
 
     // Stops or resumes all token transfers.
     // Can only be called by an address with the PAUSE_ROLE.
-    async transition set_pause_status(pause_status: bool) -> Future {
-        return f_set_pause_status(pause_status, self.caller);
+    fn set_pause_status(pause_status: bool) -> Final {
+        let caller: address = self.caller;
+        return final {
+            let role: u16 = address_to_role.get(caller);
+            assert(role & PAUSE_ROLE == PAUSE_ROLE);
+
+            pause.set(PAUSE_STATUS_INDEX, pause_status);
+        };
     }
 
-    async function f_set_pause_status(new_pause_status: bool, caller: address) {
-        let role: u16 = address_to_role.get(caller);
-        assert(role & PAUSE_ROLE == PAUSE_ROLE);
-        
-        pause.set(PAUSE_STATUS_INDEX, new_pause_status);
-    }
 
-
-    transition join(
+    fn join(
         private token_1: Token,
         private token_2: Token
     ) -> Token {
@@ -753,7 +735,7 @@ program stable_token_2.aleo {
         return new_token;
     }
 
-    transition split(
+    fn split(
         private token: Token,
         private amount: u128
     ) -> (Token, Token) {
@@ -773,12 +755,12 @@ program stable_token_2.aleo {
     // A ComplianceRecord is emitted for the investigator, who must match the stored investigator role.
     // The sender must not be frozen in the freeze list.
     // The sender's privacy is preserved by using a Credentials record.
-    async transition transfer_private_with_creds(
+    fn transfer_private_with_creds(
         recipient: address,
         amount: u128,
         input_record: Token,
         credentials: Credentials,
-    ) -> (ComplianceRecord, Token, Token, Credentials, Future) {
+    ) -> (ComplianceRecord, Token, Token, Credentials, Final) {
         let updated_record: Token = Token {
             owner: input_record.owner,
             amount: input_record.amount - amount
@@ -801,89 +783,20 @@ program stable_token_2.aleo {
             freeze_list_root: credentials.freeze_list_root,
         };
 
-        return (compliance_record, updated_record, transfer_record, credentials_record, f_transfer_private_credentials(credentials.freeze_list_root));
-    }
+        let creds_root: field = credentials.freeze_list_root;
+        return (compliance_record, updated_record, transfer_record, credentials_record, final {
+            let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
+            assert_eq(is_paused, false);
 
-    async function f_transfer_private_credentials(root: field) {
+            let current_root: field = sealance_freezelist_registry.aleo::freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
+            let window: u32 = sealance_freezelist_registry.aleo::block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
 
-        let is_paused: bool = pause.get(PAUSE_STATUS_INDEX);
-        assert_eq(is_paused, false);
-
-        let current_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(CURRENT_FREEZE_LIST_ROOT_INDEX);
-        let window: u32 = sealance_freezelist_registry.aleo/block_height_window.get(BLOCK_HEIGHT_WINDOW_INDEX);
-
-        if (current_root != root) {
-            let previous_root: field = sealance_freezelist_registry.aleo/freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
-            assert_eq(root, previous_root);
-            let updated_height: u32 = sealance_freezelist_registry.aleo/root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
-            assert(updated_height + window > block.height);
-        }
-    }
-
-    // Calculates the hash of two sibling nodes in a Merkle tree.
-    // The order of the siblings depends on the index bit (0 = left, 1 = right).
-    // Uses Poseidon hash to compute the result.
-    inline calculate_hash_for_nodes(sibling1: field, sibling2: field, indexbit: u32) -> field {
-        let poseidon_params: [field; 3] = indexbit == 0u32 ? [0field, sibling1, sibling2] : [0field, sibling2, sibling1];
-        return Poseidon4::hash_to_field(poseidon_params);
-    }
-
-    inline calculate_hash_for_leaves(sibling1: field, sibling2: field, indexbit: u32) -> field {
-        let poseidon_params: [field; 3] = indexbit == 0u32 ? [1field, sibling1, sibling2] : [1field, sibling2, sibling1];
-        return Poseidon4::hash_to_field(poseidon_params);
-    }
-
-    // Calculates the Merkle root and the depth of a Merkle proof path.
-    // Iteratively hashes the sibling path based on the leaf index to reconstruct the root.
-    // Stops when a zero field is encountered in the siblings array, indicating the end of the valid path.
-    // Returns the calculated root and the actual depth reached.
-    inline calculate_root_depth_siblings(merkle_proof: MerkleProof) -> (public field, public u32) {
-        let root: field = calculate_hash_for_leaves(merkle_proof.siblings[0u8], merkle_proof.siblings[1u8],  merkle_proof.leaf_index % 2u32);
-        for i: u32 in 2u32..MAX_TREE_DEPTH + 1u32 {
-            if (merkle_proof.siblings[i] == 0field) {
-                return (root, i - 1u32);
+            if (current_root != creds_root) {
+                let previous_root: field = sealance_freezelist_registry.aleo::freeze_list_root.get(PREVIOUS_FREEZE_LIST_ROOT_INDEX);
+                assert_eq(creds_root, previous_root);
+                let updated_height: u32 = sealance_freezelist_registry.aleo::root_updated_height.get(ROOT_UPDATED_HEIGHT_INDEX);
+                assert(updated_height + window > block.height);
             }
-            root = calculate_hash_for_nodes(root, merkle_proof.siblings[i], (merkle_proof.leaf_index / (2u32**(i-1u32))) % 2u32);
-        }
-        return (root, MAX_TREE_DEPTH);
-    }
-
-    // Verifies non-inclusion of an address in a Merkle tree sorted in ascending order by address (as field).
-    // Accepts two Merkle proofs representing the neighboring leaves around the missing address.
-    // Returns the common Merkle root if the address is proven to be outside the tree.
-    // If the tree is not sorted correctly, this function may return incorrect results.
-    inline verify_non_inclusion(addr: address, merkle_proofs: [MerkleProof;2]) -> field {
-        let (root1, depth1): (field, u32)= calculate_root_depth_siblings(merkle_proofs[0u32]);
-        let (root2, depth2): (field, u32) = calculate_root_depth_siblings(merkle_proofs[1u32]);
-
-        // Ensure the roots from the merkle proofs are the same
-        assert_eq(root1, root2);
-        // Ensure the depth of the merkle proofs is the same
-        assert_eq(depth1, depth2);
-        
-        let addr_field: field = addr as field;
-        if (merkle_proofs[0u32].leaf_index == merkle_proofs[1u32].leaf_index) {
-            // Ensure that if the address is the most left leaf, it is less than the first sibling
-            if (merkle_proofs[0u32].leaf_index == 0u32) {
-                assert(addr_field < merkle_proofs[0u32].siblings[0u32]);
-            } else {
-                // Ensure that if the address is the most right leaf
-                let last_index_leaf: u32 = 2u32 ** depth1 - 1u32;
-                assert_eq(merkle_proofs[0u32].leaf_index, last_index_leaf);
-                // Ensure that the address is bigger than the first sibling
-                assert(addr_field > merkle_proofs[0u32].siblings[0u32]);
-            }
-        } else {
-            // Ensure the address is in between the provided leaves
-            assert(addr_field > merkle_proofs[0u32].siblings[0u32]);
-            assert(addr_field < merkle_proofs[1u32].siblings[0u32]);
-            // Ensure that the leaf indexes are not greater than the last possible leaf index
-            let last_index_leaf: u32 = 2u32 ** depth1 - 1u32;
-            assert(merkle_proofs[1u32].leaf_index <= last_index_leaf);
-            // Ensure the leaves are adjacent
-            assert_eq(merkle_proofs[0u32].leaf_index + 1u32, merkle_proofs[1u32].leaf_index);
-        }
-        
-        return root1;
+        });
     }
 }

--- a/test/amm_pool.test.ts
+++ b/test/amm_pool.test.ts
@@ -1,0 +1,842 @@
+import { ExecutionMode } from "@doko-js/core";
+import { BaseContract } from "../contract/base-contract";
+import {
+  BLOCK_HEIGHT_WINDOW,
+  BLOCK_HEIGHT_WINDOW_INDEX,
+  BURNER_ROLE,
+  CURRENT_FREEZE_LIST_ROOT_INDEX,
+  FREEZELIST_MANAGER_ROLE,
+  FREEZE_LIST_LAST_INDEX,
+  MANAGER_ROLE,
+  MAX_TREE_DEPTH,
+  MINTER_ROLE,
+  NONE_ROLE,
+  fundedAmount,
+} from "../lib/Constants";
+import { fundWithCredits } from "../lib/Fund";
+import { deployIfNotDeployed } from "../lib/Deploy";
+import { getLeafIndices, getSiblingPath } from "../lib/FreezeList";
+import { initializeProgram } from "../lib/Initalize";
+import {
+  buildTree,
+  calculateAddLiquidityQuote,
+  calculateExchangeQuote,
+  calculateRemoveLiquidityQuote,
+  generateLeaves,
+  sleep,
+  stringToBigInt,
+} from "@sealance-io/policy-engine-aleo";
+import { Merkle_treeContract } from "../artifacts/js/merkle_tree";
+import { Multisig_coreContract } from "../artifacts/js/multisig_core";
+import { Sealance_freezelist_registryContract } from "../artifacts/js/sealance_freezelist_registry";
+import { Stable_token_1Contract } from "../artifacts/js/stable_token_1";
+import { Stable_token_2Contract } from "../artifacts/js/stable_token_2";
+import { Lp_tokenContract } from "../artifacts/js/lp_token";
+import { Amm_poolContract } from "../artifacts/js/amm_pool";
+import { decryptToken as decryptStableToken1 } from "../artifacts/js/leo2js/stable_token_1";
+import { decryptToken as decryptStableToken2 } from "../artifacts/js/leo2js/stable_token_2";
+import { decryptToken as decryptLpToken } from "../artifacts/js/leo2js/lp_token";
+import {
+  decryptLP_Voucher,
+  decryptStable_Token_1_Voucher,
+  decryptStable_Token_2_Voucher,
+} from "../artifacts/js/leo2js/amm_pool";
+import { Token as StableToken1Token } from "../artifacts/js/types/stable_token_1";
+import { Token as StableToken2Token } from "../artifacts/js/types/stable_token_2";
+import { Token as LpToken } from "../artifacts/js/types/lp_token";
+import { LP_Voucher, Stable_Token_1_Voucher, Stable_Token_2_Voucher } from "../artifacts/js/types/amm_pool";
+import { updateAddressToRole } from "../lib/Role";
+
+const mode = ExecutionMode.SnarkExecute;
+const contract = new BaseContract({ mode });
+
+// The order must match the configured accounts in aleo-config.js.
+const [deployerAddress, adminAddress, , frozenAccount, account] = contract.getAccounts();
+const deployerPrivKey = contract.getPrivateKey(deployerAddress);
+const adminPrivKey = contract.getPrivateKey(adminAddress);
+const frozenAccountPrivKey = contract.getPrivateKey(frozenAccount);
+const accountPrivKey = contract.getPrivateKey(account);
+
+const merkleTreeContract = new Merkle_treeContract({
+  mode,
+  privateKey: deployerPrivKey,
+});
+const multiSigContract = new Multisig_coreContract({
+  mode,
+  privateKey: deployerPrivKey,
+});
+const freezeRegistryContract = new Sealance_freezelist_registryContract({
+  mode,
+  privateKey: deployerPrivKey,
+});
+const freezeRegistryContractForAdmin = new Sealance_freezelist_registryContract({
+  mode,
+  privateKey: adminPrivKey,
+});
+
+const stableToken1Contract = new Stable_token_1Contract({
+  mode,
+  privateKey: deployerPrivKey,
+});
+const stableToken1ContractForAdmin = new Stable_token_1Contract({
+  mode,
+  privateKey: adminPrivKey,
+});
+
+const stableToken2Contract = new Stable_token_2Contract({
+  mode,
+  privateKey: deployerPrivKey,
+});
+const stableToken2ContractForAdmin = new Stable_token_2Contract({
+  mode,
+  privateKey: adminPrivKey,
+});
+
+const lpTokenContract = new Lp_tokenContract({
+  mode,
+  privateKey: deployerPrivKey,
+});
+const lpTokenContractForAdmin = new Lp_tokenContract({
+  mode,
+  privateKey: adminPrivKey,
+});
+
+const ammPoolContract = new Amm_poolContract({
+  mode,
+  privateKey: deployerPrivKey,
+});
+const ammPoolContractForAdmin = new Amm_poolContract({
+  mode,
+  privateKey: adminPrivKey,
+});
+const ammPoolContractForFrozenAccount = new Amm_poolContract({
+  mode,
+  privateKey: frozenAccountPrivKey,
+});
+const ammPoolContractForAccount = new Amm_poolContract({
+  mode,
+  privateKey: accountPrivKey,
+});
+
+const stableToken1Name = stringToBigInt("Stable Token 1");
+const stableToken2Name = stringToBigInt("Stable Token 2");
+const lpTokenName = stringToBigInt("LP Token");
+
+const stableToken1Symbol = stringToBigInt("STABLE_TKN_1");
+const stableToken2Symbol = stringToBigInt("STABLE_TKN_2");
+const lpTokenSymbol = stringToBigInt("LP_TOKEN");
+
+const decimals = 6;
+const maxSupply = 1_000_000_000_000_000n;
+const tokenAdminRole = MANAGER_ROLE + MINTER_ROLE + BURNER_ROLE;
+const ammLpRole = MINTER_ROLE + BURNER_ROLE;
+
+const initialMintAmount = 300_000n;
+const initialDepositToken1 = 100_000n;
+const initialDepositToken2 = 100_000n;
+const secondDepositToken1 = 20_000n;
+const secondDepositToken2 = 18_000n;
+const exchange1For2Input = 10_000n;
+const exchange2For1Input = 8_000n;
+const adminFeeSeedToken1 = 3_000n;
+const adminFeeSeedToken2 = 2_000n;
+
+const STORAGE_KEY = false;
+
+const initialLpVoucherId = 101n;
+const secondLpVoucherId = 102n;
+const exchangeToken2VoucherId = 201n;
+const exchangeToken1VoucherId = 202n;
+const removeLiquidityToken1VoucherId = 301n;
+const removeLiquidityToken2VoucherId = 302n;
+const frozenExchangeToken2RejectedVoucherId = 1002n;
+const optimisticExchangeToken2RejectedVoucherId = 902n;
+const frozenExchangeToken1RejectedVoucherId = 1003n;
+const optimisticExchangeToken1RejectedVoucherId = 903n;
+const optimisticRemoveLiquidityToken1VoucherId = 904n;
+const optimisticRemoveLiquidityToken2VoucherId = 905n;
+
+function subtractBuffer(amount: bigint, buffer: bigint): bigint {
+  return amount > buffer ? amount - buffer : 0n;
+}
+
+async function waitForOutputs(tx: { wait: () => Promise<unknown> }) {
+  return (await tx.wait()) as any[];
+}
+
+async function getPoolState() {
+  return {
+    stableToken1Balance: await ammPoolContract.stable_token_1_balance__(STORAGE_KEY, 0n),
+    stableToken2Balance: await ammPoolContract.stable_token_2_balance__(STORAGE_KEY, 0n),
+    stableToken1Reserved: await ammPoolContract.stable_token_1_reserved__(STORAGE_KEY, 0n),
+    stableToken2Reserved: await ammPoolContract.stable_token_2_reserved__(STORAGE_KEY, 0n),
+    lpTokenReserved: await ammPoolContract.lp_token_reserved__(STORAGE_KEY, 0n),
+  };
+}
+
+async function getLpTotalSupply() {
+  const tokenInfo = await lpTokenContract.token_info(true);
+  const lpTokenReserved = await ammPoolContract.lp_token_reserved__(STORAGE_KEY, 0n);
+  return tokenInfo.supply + lpTokenReserved;
+}
+
+async function assertPoolBalances(stableToken1Balance: bigint, stableToken2Balance: bigint) {
+  expect(await ammPoolContract.stable_token_1_balance__(STORAGE_KEY)).toBe(stableToken1Balance);
+  expect(await ammPoolContract.stable_token_2_balance__(STORAGE_KEY)).toBe(stableToken2Balance);
+}
+
+let root: bigint;
+let accountMerkleProof: { siblings: any[]; leaf_index: any }[];
+let frozenAccountMerkleProof: { siblings: any[]; leaf_index: any }[];
+
+let frozenAccountStableToken1Record: StableToken1Token;
+let frozenAccountStableToken2Record: StableToken2Token;
+let accountStableToken1Record: StableToken1Token;
+let accountStableToken2Record: StableToken2Token;
+
+let initialLpTokenRecord: LpToken;
+let redeemedLpTokenRecord: LpToken;
+let initialLpVoucherRecord: LP_Voucher;
+
+let exchangeToken2VoucherRecord: Stable_Token_2_Voucher;
+let exchangeToken1VoucherRecord: Stable_Token_1_Voucher;
+let removeLiquidityToken1VoucherRecord: Stable_Token_1_Voucher;
+let removeLiquidityToken2VoucherRecord: Stable_Token_2_Voucher;
+let secondLpVoucherRecord: LP_Voucher;
+
+describe("test amm pool program", () => {
+  beforeAll(async () => {
+    await fundWithCredits(deployerPrivKey, adminAddress, fundedAmount);
+    await fundWithCredits(deployerPrivKey, frozenAccount, fundedAmount);
+    await fundWithCredits(deployerPrivKey, account, fundedAmount);
+
+    await deployIfNotDeployed(merkleTreeContract);
+    await deployIfNotDeployed(multiSigContract);
+    await deployIfNotDeployed(freezeRegistryContract);
+    await deployIfNotDeployed(stableToken1Contract);
+    await deployIfNotDeployed(stableToken2Contract);
+    await deployIfNotDeployed(lpTokenContract);
+    await deployIfNotDeployed(ammPoolContract);
+
+    const leaves = generateLeaves([frozenAccount]);
+    const tree = buildTree(leaves);
+    root = tree[tree.length - 1];
+
+    const accountLeafIndices = getLeafIndices(tree, account);
+    const frozenAccountLeafIndices = getLeafIndices(tree, frozenAccount);
+
+    accountMerkleProof = [
+      getSiblingPath(tree, accountLeafIndices[0], MAX_TREE_DEPTH),
+      getSiblingPath(tree, accountLeafIndices[1], MAX_TREE_DEPTH),
+    ];
+    frozenAccountMerkleProof = [
+      getSiblingPath(tree, frozenAccountLeafIndices[0], MAX_TREE_DEPTH),
+      getSiblingPath(tree, frozenAccountLeafIndices[1], MAX_TREE_DEPTH),
+    ];
+
+    await initializeProgram(stableToken1Contract, [
+      stableToken1Name,
+      stableToken1Symbol,
+      decimals,
+      maxSupply,
+      adminAddress,
+    ]);
+    await initializeProgram(stableToken2Contract, [
+      stableToken2Name,
+      stableToken2Symbol,
+      decimals,
+      maxSupply,
+      adminAddress,
+    ]);
+    await initializeProgram(lpTokenContract, [lpTokenName, lpTokenSymbol, decimals, maxSupply, adminAddress]);
+    await initializeProgram(freezeRegistryContract, [adminAddress, BLOCK_HEIGHT_WINDOW]);
+
+    await updateAddressToRole(freezeRegistryContractForAdmin, adminAddress, MANAGER_ROLE + FREEZELIST_MANAGER_ROLE);
+
+    if (!(await freezeRegistryContract.freeze_list(frozenAccount, false))) {
+      const currentRoot = await freezeRegistryContract.freeze_list_root(CURRENT_FREEZE_LIST_ROOT_INDEX);
+      const lastIndex = await freezeRegistryContract.freeze_list_last_index(FREEZE_LIST_LAST_INDEX);
+      const tx = await freezeRegistryContractForAdmin.update_freeze_list(
+        frozenAccount,
+        true,
+        lastIndex + 1,
+        currentRoot,
+        root,
+      );
+      await tx.wait();
+    }
+
+    await updateAddressToRole(stableToken1ContractForAdmin, adminAddress, tokenAdminRole);
+    await updateAddressToRole(stableToken2ContractForAdmin, adminAddress, tokenAdminRole);
+    await updateAddressToRole(lpTokenContractForAdmin, adminAddress, tokenAdminRole);
+    await updateAddressToRole(lpTokenContractForAdmin, ammPoolContract.address(), ammLpRole);
+
+    const mintAccountStableToken1Tx = await stableToken1ContractForAdmin.mint_private(account, initialMintAmount);
+    const [, encryptedAccountStableToken1Record] = await waitForOutputs(mintAccountStableToken1Tx);
+    accountStableToken1Record = decryptStableToken1(encryptedAccountStableToken1Record, accountPrivKey);
+
+    const mintFrozenStableToken1Tx = await stableToken1ContractForAdmin.mint_private(frozenAccount, initialMintAmount);
+    const [, encryptedFrozenStableToken1Record] = await waitForOutputs(mintFrozenStableToken1Tx);
+    frozenAccountStableToken1Record = decryptStableToken1(encryptedFrozenStableToken1Record, frozenAccountPrivKey);
+
+    const mintAccountStableToken2Tx = await stableToken2ContractForAdmin.mint_private(account, initialMintAmount);
+    const [, encryptedAccountStableToken2Record] = await waitForOutputs(mintAccountStableToken2Tx);
+    accountStableToken2Record = decryptStableToken2(encryptedAccountStableToken2Record, accountPrivKey);
+
+    const mintFrozenStableToken2Tx = await stableToken2ContractForAdmin.mint_private(frozenAccount, initialMintAmount);
+    const [, encryptedFrozenStableToken2Record] = await waitForOutputs(mintFrozenStableToken2Tx);
+    frozenAccountStableToken2Record = decryptStableToken2(encryptedFrozenStableToken2Record, frozenAccountPrivKey);
+  });
+
+  test(`test initialize`, async () => {
+    expect(await ammPoolContract.initialized(true, false)).toBe(false);
+
+    if (deployerAddress !== adminAddress) {
+      const rejectedTx = await ammPoolContract.initialize();
+      await expect(rejectedTx.wait()).rejects.toThrow();
+    }
+
+    const tx = await ammPoolContractForAdmin.initialize();
+    await tx.wait();
+
+    await assertPoolBalances(0n, 0n);
+    expect(await ammPoolContract.initialized(true)).toBe(true);
+    expect(await ammPoolContract.stable_token_1_reserved__(STORAGE_KEY)).toBe(0n);
+    expect(await ammPoolContract.stable_token_2_reserved__(STORAGE_KEY)).toBe(0n);
+    expect(await ammPoolContract.lp_token_reserved__(STORAGE_KEY)).toBe(0n);
+
+    const rejectedTx = await ammPoolContractForAdmin.initialize();
+    await expect(rejectedTx.wait()).rejects.toThrow();
+  });
+
+  test(`test add_liquidity`, async () => {
+    // The first liquidity deposit should use the initial-liquidity branch.
+    const initialQuote = calculateAddLiquidityQuote({
+      stableToken1Amount: initialDepositToken1,
+      stableToken2Amount: initialDepositToken2,
+      stableToken1Balance: 0n,
+      stableToken2Balance: 0n,
+      lpTokenSupply: 0n,
+    });
+    const initialMinMintAmount = subtractBuffer(initialQuote.mintAmount, 25n);
+
+    // Frozen accounts cannot add liquidity
+    await expect(
+      ammPoolContractForFrozenAccount.add_liquidity(
+        initialDepositToken1,
+        initialDepositToken2,
+        frozenAccountStableToken1Record,
+        frozenAccountStableToken2Record,
+        initialQuote.mintAmount,
+        frozenAccountMerkleProof,
+        frozenAccountMerkleProof,
+        initialLpVoucherId,
+      ),
+    ).rejects.toThrow();
+
+    // Transactions with an optimistic minimum mint amount must fail.
+    const optimisticRejectedTx = await ammPoolContractForAccount.add_liquidity(
+      initialDepositToken1,
+      initialDepositToken2,
+      accountStableToken1Record,
+      accountStableToken2Record,
+      initialQuote.mintAmount + 1n,
+      accountMerkleProof,
+      accountMerkleProof,
+      initialLpVoucherId,
+    );
+    await expect(optimisticRejectedTx.wait()).rejects.toThrow();
+
+    // Initial liquidity cannot be added with a zero token amount.
+    const zeroAmountInitialDepositRejectedTx = await ammPoolContractForAccount.add_liquidity(
+      0n,
+      initialDepositToken2,
+      accountStableToken1Record,
+      accountStableToken2Record,
+      0n,
+      accountMerkleProof,
+      accountMerkleProof,
+      initialLpVoucherId,
+    );
+    await expect(zeroAmountInitialDepositRejectedTx.wait()).rejects.toThrow();
+
+    const initialAddLiquidityTx = await ammPoolContractForAccount.add_liquidity(
+      initialDepositToken1,
+      initialDepositToken2,
+      accountStableToken1Record,
+      accountStableToken2Record,
+      initialMinMintAmount,
+      accountMerkleProof,
+      accountMerkleProof,
+      initialLpVoucherId,
+    );
+    const [, , , encryptedInitialLpVoucherRecord] = await waitForOutputs(initialAddLiquidityTx);
+
+    // I need to fix the decryption of external records, I will take a look on existing tests and update it accordingly
+    accountStableToken1Record = decryptStableToken1(
+      (initialAddLiquidityTx as any).transaction.execution.transitions[0].outputs[1],
+      accountPrivKey,
+    );
+    accountStableToken2Record = decryptStableToken2(
+      (initialAddLiquidityTx as any).transaction.execution.transitions[1].outputs[1],
+      accountPrivKey,
+    );
+    initialLpTokenRecord = decryptLpToken(
+      (initialAddLiquidityTx as any).transaction.execution.transitions[2].outputs[1],
+      accountPrivKey,
+    );
+    initialLpVoucherRecord = decryptLP_Voucher(encryptedInitialLpVoucherRecord, accountPrivKey);
+
+    const initialVoucherAmount = initialQuote.mintAmount - initialMinMintAmount;
+
+    expect(accountStableToken1Record.amount).toBe(initialMintAmount - initialDepositToken1);
+    expect(accountStableToken2Record.amount).toBe(initialMintAmount - initialDepositToken2);
+    expect(initialLpTokenRecord.amount).toBe(initialMinMintAmount);
+    expect(initialLpVoucherRecord.owner).toBe(account);
+    expect(initialLpVoucherRecord.voucher_id).toBe(initialLpVoucherId);
+
+    expect(await ammPoolContract.vouchers(initialLpVoucherId)).toBe(initialVoucherAmount);
+    expect(await ammPoolContract.lp_token_reserved__(STORAGE_KEY)).toBe(initialVoucherAmount);
+
+    await assertPoolBalances(initialDepositToken1, initialDepositToken2);
+
+    expect(await stableToken1Contract.balances(ammPoolContract.address())).toBe(initialDepositToken1);
+    expect(await stableToken2Contract.balances(ammPoolContract.address())).toBe(initialDepositToken2);
+
+    // The second liquidity deposit should use the existing-liquidity branch.
+    const poolStateBeforeSecondDeposit = await getPoolState();
+
+    const lpTokenSupplyBeforeSecondDeposit = await getLpTotalSupply();
+
+    const secondQuote = calculateAddLiquidityQuote({
+      stableToken1Amount: secondDepositToken1,
+      stableToken2Amount: secondDepositToken2,
+      stableToken1Balance: poolStateBeforeSecondDeposit.stableToken1Balance,
+      stableToken2Balance: poolStateBeforeSecondDeposit.stableToken2Balance,
+      lpTokenSupply: lpTokenSupplyBeforeSecondDeposit,
+    });
+
+    const secondMinMintAmount = subtractBuffer(secondQuote.mintAmount, 10n);
+
+    // Transactions with an optimistic minimum mint amount must also fail after initialization.
+    const optimisticSecondDepositRejectedTx = await ammPoolContractForAccount.add_liquidity(
+      secondDepositToken1,
+      secondDepositToken2,
+      accountStableToken1Record,
+      accountStableToken2Record,
+      secondQuote.mintAmount + 1n,
+      accountMerkleProof,
+      accountMerkleProof,
+      secondLpVoucherId,
+    );
+    await expect(optimisticSecondDepositRejectedTx.wait()).rejects.toThrow();
+
+    const secondAddLiquidityTx = await ammPoolContractForAccount.add_liquidity(
+      secondDepositToken1,
+      secondDepositToken2,
+      accountStableToken1Record,
+      accountStableToken2Record,
+      secondMinMintAmount,
+      accountMerkleProof,
+      accountMerkleProof,
+      secondLpVoucherId,
+    );
+    const [, , , encryptedAccountLpVoucherRecord] = await waitForOutputs(secondAddLiquidityTx);
+
+    accountStableToken1Record = decryptStableToken1(
+      (secondAddLiquidityTx as any).transaction.execution.transitions[0].outputs[1],
+      accountPrivKey,
+    );
+    accountStableToken2Record = decryptStableToken2(
+      (secondAddLiquidityTx as any).transaction.execution.transitions[1].outputs[1],
+      accountPrivKey,
+    );
+    const accountLpTokenRecord = decryptLpToken(
+      (secondAddLiquidityTx as any).transaction.execution.transitions[2].outputs[1],
+      accountPrivKey,
+    );
+    secondLpVoucherRecord = decryptLP_Voucher(encryptedAccountLpVoucherRecord, accountPrivKey);
+
+    expect(accountStableToken1Record.amount).toBe(initialMintAmount - initialDepositToken1 - secondDepositToken1);
+    expect(accountStableToken2Record.amount).toBe(initialMintAmount - initialDepositToken2 - secondDepositToken2);
+    expect(accountLpTokenRecord.amount).toBe(secondMinMintAmount);
+    expect(secondLpVoucherRecord.voucher_id).toBe(secondLpVoucherId);
+
+    expect(await ammPoolContract.vouchers(secondLpVoucherId)).toBe(secondQuote.mintAmount - secondMinMintAmount);
+    await assertPoolBalances(secondQuote.newStableToken1Balance, secondQuote.newStableToken2Balance);
+
+    // Reusing an existing voucher id must fail.
+    const duplicateVoucherRejectedTx = await ammPoolContractForAccount.add_liquidity(
+      1n,
+      1n,
+      accountStableToken1Record,
+      accountStableToken2Record,
+      0n,
+      accountMerkleProof,
+      accountMerkleProof,
+      initialLpVoucherId,
+    );
+    await expect(duplicateVoucherRejectedTx.wait()).rejects.toThrow();
+  });
+
+  test(`test redeem_lp_token_voucher`, async () => {
+    const lpTokenReservedBefore = await ammPoolContract.lp_token_reserved__(STORAGE_KEY);
+    expect(lpTokenReservedBefore).toBeGreaterThan(0n);
+
+    const voucherAmount = await ammPoolContract.vouchers(initialLpVoucherRecord.voucher_id);
+    expect(voucherAmount).toBeGreaterThan(0n);
+
+    // It is not possible to redeem more than the voucher amount.
+    const rejectedTx = await ammPoolContractForAccount.redeem_lp_token_voucher(
+      initialLpVoucherRecord,
+      voucherAmount + 1n,
+    );
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    // Redeeming the voucher should mint the reserved LP amount.
+    const tx = await ammPoolContractForAccount.redeem_lp_token_voucher(initialLpVoucherRecord, voucherAmount);
+    const [, encryptedUpdatedLpVoucherRecord] = await waitForOutputs(tx);
+
+    redeemedLpTokenRecord = decryptLpToken((tx as any).transaction.execution.transitions[0].outputs[1], accountPrivKey);
+    initialLpVoucherRecord = decryptLP_Voucher(encryptedUpdatedLpVoucherRecord, accountPrivKey);
+
+    expect(redeemedLpTokenRecord.amount).toBe(voucherAmount);
+    expect(await ammPoolContract.vouchers(initialLpVoucherRecord.voucher_id)).toBe(0n);
+    expect(lpTokenReservedBefore - (await ammPoolContract.lp_token_reserved__(STORAGE_KEY))).toBe(voucherAmount);
+  });
+
+  test(`test exchange_1_for_2`, async () => {
+    const poolStateBefore = await getPoolState();
+    const quote = calculateExchangeQuote({
+      inputAmount: exchange1For2Input,
+      inputTokenBalance: poolStateBefore.stableToken1Balance,
+      outputTokenBalance: poolStateBefore.stableToken2Balance,
+    });
+    const minOutputAmount = subtractBuffer(quote.netOutputAmount, 7n);
+
+    await expect(
+      ammPoolContractForFrozenAccount.exchange_1_for_2(
+        exchange1For2Input,
+        minOutputAmount,
+        frozenAccountStableToken1Record,
+        frozenAccountMerkleProof,
+        frozenExchangeToken2RejectedVoucherId,
+      ),
+    ).rejects.toThrow();
+
+    // Transactions with an optimistic minimum output amount must fail.
+    const optimisticRejectedTx = await ammPoolContractForAccount.exchange_1_for_2(
+      exchange1For2Input,
+      quote.netOutputAmount + 1n,
+      accountStableToken1Record,
+      accountMerkleProof,
+      optimisticExchangeToken2RejectedVoucherId,
+    );
+    await expect(optimisticRejectedTx.wait()).rejects.toThrow();
+
+    // A valid exchange should return the minimum output and reserve the remainder in a voucher.
+    const tx = await ammPoolContractForAccount.exchange_1_for_2(
+      exchange1For2Input,
+      minOutputAmount,
+      accountStableToken1Record,
+      accountMerkleProof,
+      exchangeToken2VoucherId,
+    );
+    const [, , encryptedStableToken2Voucher] = await waitForOutputs(tx);
+
+    accountStableToken1Record = decryptStableToken1(
+      (tx as any).transaction.execution.transitions[0].outputs[1],
+      accountPrivKey,
+    );
+    const accountStableToken2Output = decryptStableToken2(
+      (tx as any).transaction.execution.transitions[1].outputs[1],
+      accountPrivKey,
+    );
+    exchangeToken2VoucherRecord = decryptStable_Token_2_Voucher(encryptedStableToken2Voucher, accountPrivKey);
+
+    expect(accountStableToken1Record.amount).toBe(
+      initialMintAmount - initialDepositToken1 - secondDepositToken1 - exchange1For2Input,
+    );
+    expect(accountStableToken2Output.amount).toBe(minOutputAmount);
+    expect(exchangeToken2VoucherRecord.voucher_id).toBe(exchangeToken2VoucherId);
+
+    expect(await ammPoolContract.vouchers(exchangeToken2VoucherId)).toBe(quote.netOutputAmount - minOutputAmount);
+    expect(await ammPoolContract.stable_token_2_reserved__(STORAGE_KEY)).toBe(quote.netOutputAmount - minOutputAmount);
+    await assertPoolBalances(quote.newInputStableTokenBalance, quote.newOutputStableTokenBalance);
+
+    // Reusing a voucher id must fail.
+    const duplicateVoucherRejectedTx = await ammPoolContractForAccount.exchange_1_for_2(
+      1n,
+      0n,
+      accountStableToken1Record,
+      accountMerkleProof,
+      exchangeToken2VoucherId,
+    );
+    await expect(duplicateVoucherRejectedTx.wait()).rejects.toThrow();
+  });
+
+  test(`test redeem_stable_token_2_voucher`, async () => {
+    const voucherAmount = await ammPoolContract.vouchers(exchangeToken2VoucherRecord.voucher_id);
+    expect(voucherAmount).toBeGreaterThan(0n);
+
+    // It is not possible to redeem more than the voucher amount.
+    const rejectedTx = await ammPoolContractForAccount.redeem_stable_token_2_voucher(
+      exchangeToken2VoucherRecord,
+      voucherAmount + 1n,
+    );
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    // Redeeming the voucher should return the reserved output amount.
+    const tx = await ammPoolContractForAccount.redeem_stable_token_2_voucher(
+      exchangeToken2VoucherRecord,
+      voucherAmount,
+    );
+    const [, encryptedUpdatedStableToken2Voucher] = await waitForOutputs(tx);
+
+    const stableToken2VoucherOutput = decryptStableToken2(
+      (tx as any).transaction.execution.transitions[0].outputs[1],
+      accountPrivKey,
+    );
+    exchangeToken2VoucherRecord = decryptStable_Token_2_Voucher(encryptedUpdatedStableToken2Voucher, accountPrivKey);
+
+    expect(stableToken2VoucherOutput.amount).toBe(voucherAmount);
+    expect(await ammPoolContract.vouchers(exchangeToken2VoucherRecord.voucher_id)).toBe(0n);
+    expect(await ammPoolContract.stable_token_2_reserved__(STORAGE_KEY)).toBe(0n);
+  });
+
+  test(`test exchange_2_for_1`, async () => {
+    const poolStateBefore = await getPoolState();
+    const quote = calculateExchangeQuote({
+      inputAmount: exchange2For1Input,
+      inputTokenBalance: poolStateBefore.stableToken2Balance,
+      outputTokenBalance: poolStateBefore.stableToken1Balance,
+    });
+    const minOutputAmount = subtractBuffer(quote.netOutputAmount, 5n);
+
+    // Frozen accounts cannot exchange through the pool. Use a valid quote so freeze-list membership is the only
+    // expected rejection reason.
+    await expect(
+      ammPoolContractForFrozenAccount.exchange_2_for_1(
+        exchange2For1Input,
+        minOutputAmount,
+        frozenAccountStableToken2Record,
+        frozenAccountMerkleProof,
+        frozenExchangeToken1RejectedVoucherId,
+      ),
+    ).rejects.toThrow();
+
+    // Transactions with an optimistic minimum output amount must fail.
+    const optimisticRejectedTx = await ammPoolContractForAccount.exchange_2_for_1(
+      exchange2For1Input,
+      quote.netOutputAmount + 1n,
+      accountStableToken2Record,
+      accountMerkleProof,
+      optimisticExchangeToken1RejectedVoucherId,
+    );
+    await expect(optimisticRejectedTx.wait()).rejects.toThrow();
+
+    // A valid exchange should return the minimum output and reserve the remainder in a voucher.
+    const tx = await ammPoolContractForAccount.exchange_2_for_1(
+      exchange2For1Input,
+      minOutputAmount,
+      accountStableToken2Record,
+      accountMerkleProof,
+      exchangeToken1VoucherId,
+    );
+    const [, , encryptedStableToken1Voucher] = await waitForOutputs(tx);
+
+    accountStableToken2Record = decryptStableToken2(
+      (tx as any).transaction.execution.transitions[0].outputs[1],
+      accountPrivKey,
+    );
+    const accountStableToken1Output = decryptStableToken1(
+      (tx as any).transaction.execution.transitions[1].outputs[1],
+      accountPrivKey,
+    );
+    exchangeToken1VoucherRecord = decryptStable_Token_1_Voucher(encryptedStableToken1Voucher, accountPrivKey);
+
+    expect(accountStableToken2Record.amount).toBe(
+      initialMintAmount - initialDepositToken2 - secondDepositToken2 - exchange2For1Input,
+    );
+    expect(accountStableToken1Output.amount).toBe(minOutputAmount);
+    expect(exchangeToken1VoucherRecord.voucher_id).toBe(exchangeToken1VoucherId);
+
+    expect(await ammPoolContract.vouchers(exchangeToken1VoucherId)).toBe(quote.netOutputAmount - minOutputAmount);
+    expect(await ammPoolContract.stable_token_1_reserved__(STORAGE_KEY)).toBe(quote.netOutputAmount - minOutputAmount);
+    await assertPoolBalances(quote.newOutputStableTokenBalance, quote.newInputStableTokenBalance);
+
+    // Reusing a voucher id must fail.
+    const duplicateVoucherRejectedTx = await ammPoolContractForAccount.exchange_2_for_1(
+      1n,
+      0n,
+      accountStableToken2Record,
+      accountMerkleProof,
+      exchangeToken1VoucherId,
+    );
+    await expect(duplicateVoucherRejectedTx.wait()).rejects.toThrow();
+  });
+
+  test(`test redeem_stable_token_1_voucher`, async () => {
+    const voucherAmount = await ammPoolContract.vouchers(exchangeToken1VoucherRecord.voucher_id);
+    expect(voucherAmount).toBeGreaterThan(0n);
+
+    // It is not possible to redeem more than the voucher amount.
+    const rejectedTx = await ammPoolContractForAccount.redeem_stable_token_1_voucher(
+      exchangeToken1VoucherRecord,
+      voucherAmount + 1n,
+    );
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    // Redeeming the voucher should return the reserved output amount.
+    const tx = await ammPoolContractForAccount.redeem_stable_token_1_voucher(
+      exchangeToken1VoucherRecord,
+      voucherAmount,
+    );
+    const [, encryptedUpdatedStableToken1Voucher] = await waitForOutputs(tx);
+
+    const stableToken1VoucherOutput = decryptStableToken1(
+      (tx as any).transaction.execution.transitions[0].outputs[1],
+      accountPrivKey,
+    );
+    exchangeToken1VoucherRecord = decryptStable_Token_1_Voucher(encryptedUpdatedStableToken1Voucher, accountPrivKey);
+
+    expect(stableToken1VoucherOutput.amount).toBe(voucherAmount);
+    expect(await ammPoolContract.vouchers(exchangeToken1VoucherRecord.voucher_id)).toBe(0n);
+    expect(await ammPoolContract.stable_token_1_reserved__(STORAGE_KEY)).toBe(0n);
+  });
+
+  test(`test remove_liquidity`, async () => {
+    const lpTokenAmount = redeemedLpTokenRecord.amount - 1n;
+    const poolStateBefore = await getPoolState();
+    const lpTokenSupplyBefore = await getLpTotalSupply();
+    const quote = calculateRemoveLiquidityQuote({
+      lpTokenAmount,
+      stableToken1Balance: poolStateBefore.stableToken1Balance,
+      stableToken2Balance: poolStateBefore.stableToken2Balance,
+      lpTokenSupply: lpTokenSupplyBefore,
+    });
+    const minStableToken1Amount = subtractBuffer(quote.stableToken1Amount, 9n);
+    const minStableToken2Amount = subtractBuffer(quote.stableToken2Amount, 11n);
+
+    // Transactions with optimistic minimum output amounts must fail.
+    let optimisticRejectedTx = await ammPoolContractForAccount.remove_liquidity(
+      lpTokenAmount,
+      quote.stableToken1Amount + 1n,
+      minStableToken2Amount,
+      redeemedLpTokenRecord,
+      optimisticRemoveLiquidityToken1VoucherId,
+      optimisticRemoveLiquidityToken2VoucherId,
+    );
+    await expect(optimisticRejectedTx.wait()).rejects.toThrow();
+    optimisticRejectedTx = await ammPoolContractForAccount.remove_liquidity(
+      lpTokenAmount,
+      minStableToken1Amount,
+      quote.stableToken2Amount + 1n,
+      redeemedLpTokenRecord,
+      optimisticRemoveLiquidityToken1VoucherId,
+      optimisticRemoveLiquidityToken2VoucherId,
+    );
+    await expect(optimisticRejectedTx.wait()).rejects.toThrow();
+
+    // A valid liquidity removal should burn LP tokens and issue vouchers for the withheld amounts.
+    const tx = await ammPoolContractForAccount.remove_liquidity(
+      lpTokenAmount,
+      minStableToken1Amount,
+      minStableToken2Amount,
+      redeemedLpTokenRecord,
+      removeLiquidityToken1VoucherId,
+      removeLiquidityToken2VoucherId,
+    );
+    const [, , , encryptedRemoveLiquidityToken1Voucher, encryptedRemoveLiquidityToken2Voucher] =
+      await waitForOutputs(tx);
+
+    redeemedLpTokenRecord = decryptLpToken((tx as any).transaction.execution.transitions[0].outputs[1], accountPrivKey);
+    const stableToken1Output = decryptStableToken1(
+      (tx as any).transaction.execution.transitions[1].outputs[1],
+      accountPrivKey,
+    );
+    const stableToken2Output = decryptStableToken2(
+      (tx as any).transaction.execution.transitions[2].outputs[1],
+      accountPrivKey,
+    );
+    removeLiquidityToken1VoucherRecord = decryptStable_Token_1_Voucher(
+      encryptedRemoveLiquidityToken1Voucher,
+      accountPrivKey,
+    );
+    removeLiquidityToken2VoucherRecord = decryptStable_Token_2_Voucher(
+      encryptedRemoveLiquidityToken2Voucher,
+      accountPrivKey,
+    );
+
+    expect(redeemedLpTokenRecord.amount).toBe(1n);
+    expect(stableToken1Output.amount).toBe(minStableToken1Amount);
+    expect(stableToken2Output.amount).toBe(minStableToken2Amount);
+    expect(removeLiquidityToken1VoucherRecord.voucher_id).toBe(removeLiquidityToken1VoucherId);
+    expect(removeLiquidityToken2VoucherRecord.voucher_id).toBe(removeLiquidityToken2VoucherId);
+
+    expect(await ammPoolContract.vouchers(removeLiquidityToken1VoucherId)).toBe(
+      quote.stableToken1Amount - minStableToken1Amount,
+    );
+    expect(await ammPoolContract.vouchers(removeLiquidityToken2VoucherId)).toBe(
+      quote.stableToken2Amount - minStableToken2Amount,
+    );
+    expect(await ammPoolContract.stable_token_1_reserved__(STORAGE_KEY)).toBe(
+      quote.stableToken1Amount - minStableToken1Amount,
+    );
+    expect(await ammPoolContract.stable_token_2_reserved__(STORAGE_KEY)).toBe(
+      quote.stableToken2Amount - minStableToken2Amount,
+    );
+    await assertPoolBalances(quote.newStableToken1Balance, quote.newStableToken2Balance);
+
+    // Reusing a voucher id must fail.
+    const duplicateVoucherRejectedTx = await ammPoolContractForAccount.remove_liquidity(
+      1n,
+      0n,
+      0n,
+      redeemedLpTokenRecord,
+      removeLiquidityToken1VoucherId,
+      removeLiquidityToken2VoucherId,
+    );
+    await expect(duplicateVoucherRejectedTx.wait()).rejects.toThrow();
+  });
+
+  test(`test withdraw_admin_fees`, async () => {
+    const nonAdminRejectedTx = await ammPoolContractForAccount.withdraw_admin_fees(0n, 0n);
+    await expect(nonAdminRejectedTx.wait()).rejects.toThrow();
+
+    const mintStableToken1FeeSeedTx = await stableToken1ContractForAdmin.mint_public(adminAddress, adminFeeSeedToken1);
+    await mintStableToken1FeeSeedTx.wait();
+    const mintStableToken2FeeSeedTx = await stableToken2ContractForAdmin.mint_public(adminAddress, adminFeeSeedToken2);
+    await mintStableToken2FeeSeedTx.wait();
+
+    const transferStableToken1FeeSeedTx = await stableToken1ContractForAdmin.transfer_public(
+      ammPoolContract.address(),
+      adminFeeSeedToken1,
+    );
+    await transferStableToken1FeeSeedTx.wait();
+    const transferStableToken2FeeSeedTx = await stableToken2ContractForAdmin.transfer_public(
+      ammPoolContract.address(),
+      adminFeeSeedToken2,
+    );
+    await transferStableToken2FeeSeedTx.wait();
+
+    const rejectedTx = await ammPoolContractForAdmin.withdraw_admin_fees(adminFeeSeedToken1 + 1n, adminFeeSeedToken2);
+    await expect(rejectedTx.wait()).rejects.toThrow();
+
+    const stableToken1PoolBalanceBefore = await stableToken1Contract.balances(ammPoolContract.address());
+    const stableToken2PoolBalanceBefore = await stableToken2Contract.balances(ammPoolContract.address());
+
+    const withdrawAdminFeesTx = await ammPoolContractForAdmin.withdraw_admin_fees(
+      adminFeeSeedToken1,
+      adminFeeSeedToken2,
+    );
+    await withdrawAdminFeesTx.wait();
+
+    expect(await stableToken1Contract.balances(ammPoolContract.address())).toBe(
+      stableToken1PoolBalanceBefore - adminFeeSeedToken1,
+    );
+    expect(await stableToken2Contract.balances(ammPoolContract.address())).toBe(
+      stableToken2PoolBalanceBefore - adminFeeSeedToken2,
+    );
+  });
+});


### PR DESCRIPTION
There are four new programs: `stable_coin_1`, `stable_coin_2`,`lp_token`, and `amm_pool`.
`stable_coin_1`, `stable_coin_2`, and `lp_token` are identical to compliant_transfer_template.
amm_pool includes: `initialize`, `add_liquidity`, `remove_liquidity`, `exchange_1_for_2`, `exchange_2_for_1`, `redeem_stable_token_1_voucher`, `redeem_stable_token_2_voucher`, `redeem_lp_token_voucher`, and `withdraw_admin_fees`.
The program uses Curve’s stable-swap formula.
It uses an external LP token program to represent liquidity provider shares.
Each token has its own voucher record type.
The upgrade mechanism is the same as in the other programs and relies on the multisig program.

What is still missing / open:

Pause functionality is not implemented yet, but I think we should add it.
- The AMM does not initialize the LP token. I’m still usure if we want to do that here.
- `remove_liquidity_imbalance` is not implemented yet. I’m not sure if it is necessary.
- Tests are not included yet.