### PR TITLE
replace GITHUB_TOKEN with GitHub App token for version workflow

### DIFF
--- a/.github/workflows/sdk-release-version.yml
+++ b/.github/workflows/sdk-release-version.yml
@@ -25,15 +25,26 @@ jobs:
   version:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    environment: release-automation
     permissions:
-      contents: write # Create release PR commits
-      pull-requests: write # Create/update release PR
+      contents: read # Checkout clone only; app token handles all writes
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ vars.SEALANCE_PUBLIC_SIGNER_APP_ID }}
+          private-key: ${{ secrets.SEALANCE_PUBLIC_SIGNER_APP_PRIVATE_KEY }}
+          repositories: compliant-transfer-aleo
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
@@ -49,4 +60,4 @@ jobs:
           title: "chore(release): version packages"
           commit: "chore(release): version packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -24,7 +24,7 @@ Releases are managed using [Changesets](https://github.com/changesets/changesets
          ↓
 3. PR merged to main
          ↓
-4. Versioning workflow creates "Version Packages" PR
+4. Versioning workflow creates "Version Packages" PR (authored by sealance-public-signer[bot], so pull_request CI runs normally)
          ↓
 5. Maintainer reviews and merges release PR
          ↓
@@ -460,6 +460,28 @@ This is the primary security gate for npm publishing. Configure at:
 - Break-glass workflow provides audited emergency path
 - Bypass would allow silent malicious publishes
 
+### `release-automation` Environment (Versioning)
+
+Used by the `version` job in `sdk-release-version.yml` to access the GitHub App private key. Configure at:
+`Repository Settings → Environments → release-automation`
+
+| Setting                 | Value       | Rationale                                                                                             |
+| ----------------------- | ----------- | ----------------------------------------------------------------------------------------------------- |
+| **Required reviewers**  | None        | Job runs automatically on every push to `main`                                                        |
+| **Deployment branches** | `main` only | Prevents other workflows or refs from accessing the environment secret unless they also run on `main` |
+
+**Secrets stored here:**
+
+| Name                                     | Value              |
+| ---------------------------------------- | ------------------ |
+| `SEALANCE_PUBLIC_SIGNER_APP_PRIVATE_KEY` | GitHub App PEM key |
+
+The `SEALANCE_PUBLIC_SIGNER_APP_ID` app identifier is stored as an org-level Actions _variable_ (not a secret) and is accessible without declaring this environment.
+
+**Why a GitHub App instead of `GITHUB_TOKEN`?**
+
+Release PRs created with `GITHUB_TOKEN` do not trigger `pull_request` CI workflows (GitHub suppresses events created by the built-in token). The `sealance-public-signer` app token creates the PR as a distinct bot identity, which allows CI to run on the release PR normally.
+
 ### How Approval Works
 
 When the publish workflow runs:
@@ -521,6 +543,10 @@ After release, verify:
 - Ensure changesets exist in `.changeset/` (not just README.md)
 - Check `sdk-release-version.yml` workflow ran successfully
 - Verify paths filter includes your changes
+- Verify the `release-automation` environment exists and has no required reviewers (a required-reviewer gate blocks automated jobs)
+- Verify the `release-automation` environment deployment branch rule allows `main`
+- Verify `SEALANCE_PUBLIC_SIGNER_APP_ID` is set as an org-level Actions variable
+- Verify `SEALANCE_PUBLIC_SIGNER_APP_PRIVATE_KEY` is set as a secret in the `release-automation` environment
 
 ### OIDC Publish Failed (404)
 

--- a/docs/SECURITY-WORKFLOWS.md
+++ b/docs/SECURITY-WORKFLOWS.md
@@ -22,15 +22,16 @@ Job-level permissions: `contents: read` (standard), `security-events: write` (SA
 
 All actions pinned to commit SHAs:
 
-| Action                              | SHA        | Version |
-| ----------------------------------- | ---------- | ------- |
-| `actions/checkout`                  | `08eba0b2` | v4.3.0  |
-| `actions/setup-node`                | `49933ea5` | v4.5.1  |
-| `actions/dependency-review-action`  | `3c4e3dcb` | v4.8.2  |
-| `docker/login-action`               | `5e57cd11` | v3.6.0  |
-| `github/codeql-action/upload-sarif` | `45c37351` | v3.31.9 |
-| `zizmorcore/zizmor-action`          | `e673c391` | v0.2.0  |
-| `sealance-io/setup-leo-action`      | `126611b3` | v1.0.0  |
+| Action                             | SHA        | Version |
+| ---------------------------------- | ---------- | ------- |
+| `actions/checkout`                 | `8e8c483d` | v6.0.1  |
+| `actions/create-github-app-token`  | `f8d387b6` | v3.0.0  |
+| `actions/dependency-review-action` | `3c4e3dcb` | v4.8.2  |
+| `actions/github-script`            | `ed597411` | v8.0.0  |
+| `actions/setup-node`               | `6044e13b` | v6.2.0  |
+| `changesets/action`                | `e0145edc` | v1.5.3  |
+| `sealance-io/setup-leo-action`     | `4491779e` | v1.1.0  |
+| `zizmorcore/zizmor-action`         | `e639db99` | v0.3.0  |
 
 ### 3. Container Image Pinning
 
@@ -76,13 +77,12 @@ Blocked licenses: GPL-2.0, GPL-3.0, AGPL (incompatible with Apache-2.0).
 
 ## Action Trust Levels
 
-| Action                         | Publisher | Trust    |
-| ------------------------------ | --------- | -------- |
-| `actions/*`                    | GitHub    | High     |
-| `github/codeql-action`         | GitHub    | High     |
-| `docker/login-action`          | Docker    | High     |
-| `zizmorcore/zizmor-action`     | Zizmor    | Medium   |
-| `sealance-io/setup-leo-action` | Sealance  | Internal |
+| Action                         | Publisher  | Trust    |
+| ------------------------------ | ---------- | -------- |
+| `actions/*`                    | GitHub     | High     |
+| `changesets/action`            | Changesets | Medium   |
+| `zizmorcore/zizmor-action`     | Zizmor     | Medium   |
+| `sealance-io/setup-leo-action` | Sealance   | Internal |
 
 ## Security Review Checklist
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                    
   
  - Root cause fixed: Release PRs created with GITHUB_TOKEN are suppressed by GitHub — pull_request CI never runs on them. Replacing it with a GitHub App installation token (bot identity) restores normal CI behavior.                                                                                                     
  - Token generation: New first step mints a short-lived token from the sealance-public-signer app, explicitly narrowed to contents: write + pull-requests: write on this repo only (repositories: compliant-transfer-aleo).
  - Secret scoping: Private key lives in the release-automation environment secret; the job now declares environment: release-automation to access it.                                                                                                                                                                       
  - GITHUB_TOKEN permissions reduced: contents: write + pull-requests: write → contents: read only; the built-in token's blast radius is reduced.                                                                                                                                                                            
  - SHA pinned via pinact with a 7-day cooldown: v3.1.1/v3.1.0 (published 5 days ago) were skipped; pinned to v3.0.0 @ f8d387b6.                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                             
## Docs updated                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                             
  - docs/SECURITY-WORKFLOWS.md: Action pinning table fully reconciled (stale versions corrected, two unused actions removed, three new actions added); trust levels table updated to match.                                                                                                                                  
  - docs/RELEASING.md: release-automation environment documented; release flow notes PR is authored by sealance-public-signer[bot]; troubleshooting section covers environment/credential misconfiguration.
                                                                                                                                                                                                                                                                                                                             
## Verification                                              
                                                                                                                                                                                                                                                                                                                             
- All three zizmor modes (default, pedantic, auditor) pass with zero security findings.
  
## Deployment
- Once merged, merging #235 should trigger the sdk version workflow