### PR TITLE
 Harden CI supply chain security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,9 @@
 # The root workspace manages all dependencies for both the root package and
 # the @sealance-io/policy-engine-aleo SDK in packages/policy-engine-sdk.
 #
-# Security note: This project uses lockfile-lint and npm ci with --ignore-scripts
-# for supply chain attack prevention. See docs/NPM-SECURITY.md for details.
+# Security note: This project uses a committed lockfile validator and npm ci
+# with --ignore-scripts --allow-git=none for supply chain attack prevention.
+# See docs/NPM-SECURITY.md for details.
 
 version: 2
 

--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,0 +1,25 @@
+# Dependency Review Action configuration
+# https://github.com/actions/dependency-review-action
+#
+# Shared by: on-pull-request-main.yml, on-pull-request-main-sdk.yml
+# Centralizes config to prevent drift between PR workflows.
+
+# Block PRs that introduce high or critical vulnerabilities
+fail-on-severity: high
+
+# Check all dependency scopes (action default is runtime only)
+fail-on-scopes:
+  - runtime
+  - development
+  - unknown
+
+# License checking deferred — manual check available via `npm run lint:licenses`
+license-check: false
+
+# Post vulnerability summary as a PR comment for developer visibility
+# Requires pull-requests: write on the dependency-review job
+# Best-effort: silently skipped on fork PRs where GITHUB_TOKEN is read-only
+comment-summary-in-pr: always
+
+# Disable OpenSSF Scorecard — not used; v4.9.0 skips the API call entirely when false
+show-openssf-scorecard: false

--- a/.github/workflows/leo-cache-warmup.yml
+++ b/.github/workflows/leo-cache-warmup.yml
@@ -30,7 +30,7 @@ jobs:
         shell: bash -eo pipefail {0}
 
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -25,7 +25,7 @@ jobs:
       run:
         shell: bash -eo pipefail {0}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -54,7 +54,7 @@ jobs:
       run:
         shell: bash -eo pipefail {0}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Discover test files

--- a/.github/workflows/on-pull-request-main-sdk.yml
+++ b/.github/workflows/on-pull-request-main-sdk.yml
@@ -20,14 +20,14 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+      pull-requests: write # Required for comment-summary-in-pr
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
-      - uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # v4.8.2
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
-          fail-on-severity: high
-          license-check: false # TODO: check licenses
+          config-file: ./.github/dependency-review-config.yml
 
   # Detect if SDK code changed (skip for non-SDK or docs-only changes)
   # NOTE: This replaces workflow-level `paths` filter. Equivalent to:
@@ -102,14 +102,11 @@ jobs:
       - name: Install dependencies
         run: npm ci --prefer-offline --ignore-scripts --no-audit --no-fund
 
-      - name: Check for vulnerabilities (production only)
-        run: npm audit --audit-level=high --omit=dev
-
       - name: Run prettier
         run: npm run format --workspace=@sealance-io/policy-engine-aleo
 
   test:
-    needs: [detect-changes, linter]
+    needs: [dependency-review, detect-changes, linter]
     if: needs.detect-changes.outputs.sdk == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/on-pull-request-main-sdk.yml
+++ b/.github/workflows/on-pull-request-main-sdk.yml
@@ -22,7 +22,7 @@ jobs:
       contents: read
       pull-requests: write # Required for comment-summary-in-pr
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
@@ -49,7 +49,7 @@ jobs:
       run:
         shell: bash -eo pipefail {0}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -85,12 +85,12 @@ jobs:
         shell: bash -eo pipefail {0}
     steps:
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           cache: "npm"
           node-version-file: ".nvmrc"
@@ -120,12 +120,12 @@ jobs:
         shell: bash -eo pipefail {0}
     steps:
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           cache: "npm"
           node-version-file: ".nvmrc"

--- a/.github/workflows/on-pull-request-main-sdk.yml
+++ b/.github/workflows/on-pull-request-main-sdk.yml
@@ -95,12 +95,15 @@ jobs:
           cache: "npm"
           node-version-file: ".nvmrc"
 
-      # Validate lockfile BEFORE npm ci (npx runs without install)
+      # Validate lockfile BEFORE npm ci (committed script, zero network deps)
       - name: Validate lockfile
-        run: npx lockfile-lint --path package-lock.json --type npm --allowed-hosts npm --validate-https
+        run: node scripts/validate-lockfile.mjs
 
       - name: Install dependencies
-        run: npm ci --prefer-offline --ignore-scripts --no-audit --no-fund
+        run: npm ci --prefer-offline --ignore-scripts --allow-git=none --no-audit --no-fund
+
+      - name: Check for vulnerabilities
+        run: npm audit --audit-level=high
 
       - name: Run prettier
         run: npm run format --workspace=@sealance-io/policy-engine-aleo
@@ -128,7 +131,7 @@ jobs:
           node-version-file: ".nvmrc"
 
       - name: Install dependencies
-        run: npm ci --prefer-offline --ignore-scripts --no-audit --no-fund
+        run: npm ci --prefer-offline --ignore-scripts --allow-git=none --no-audit --no-fund
 
       - name: Run postinstall
         run: npm run postinstall

--- a/.github/workflows/on-pull-request-main.yml
+++ b/.github/workflows/on-pull-request-main.yml
@@ -30,14 +30,14 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+      pull-requests: write # Required for comment-summary-in-pr
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6.0.1
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
-      - uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # ratchet:actions/dependency-review-action@v4.8.2
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
-          fail-on-severity: high
-          license-check: false # TODO: check licenses
+          config-file: ./.github/dependency-review-config.yml
 
   # Detect if code changed (skip tests for doc-only PRs)
   # NOTE: This replaces `paths-ignore: ["**/*.md"]` at the workflow level.
@@ -55,7 +55,7 @@ jobs:
       run:
         shell: bash -eo pipefail {0}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6.0.1
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -87,10 +87,10 @@ jobs:
       run:
         shell: bash -eo pipefail {0}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6.0.1
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # ratchet:actions/setup-node@v6.2.0
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           cache: "npm"
           node-version-file: ".nvmrc"
@@ -99,8 +99,6 @@ jobs:
         run: npx lockfile-lint --path package-lock.json --type npm --allowed-hosts npm --validate-https
       - name: Install dependencies
         run: npm ci --prefer-offline --ignore-scripts --no-audit --no-fund
-      - name: Check for vulnerabilities (production only)
-        run: npm audit --audit-level=high --omit=dev
       - name: Run postinstall
         run: npm run postinstall
       - name: Run prettier
@@ -119,7 +117,7 @@ jobs:
       run:
         shell: bash -eo pipefail {0}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6.0.1
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
       - name: Discover test files
@@ -133,7 +131,7 @@ jobs:
 
   # Devnet mode: Matrix of jobs for all tests when explicitly requested
   test-devnet:
-    needs: [detect-changes, linter, discover-tests]
+    needs: [dependency-review, detect-changes, linter, discover-tests]
     if: needs.detect-changes.outputs.code == 'true' && github.event_name == 'workflow_dispatch' && inputs.mode == 'devnet'
     permissions:
       contents: read
@@ -151,7 +149,7 @@ jobs:
 
   # Devnode mode: Single job for all tests (default for PRs and manual runs)
   test-devnode:
-    needs: [detect-changes, linter]
+    needs: [dependency-review, detect-changes, linter]
     if: needs.detect-changes.outputs.code == 'true' && (github.event_name != 'workflow_dispatch' || inputs.mode == 'devnode')
     permissions:
       contents: read

--- a/.github/workflows/on-pull-request-main.yml
+++ b/.github/workflows/on-pull-request-main.yml
@@ -32,7 +32,7 @@ jobs:
       contents: read
       pull-requests: write # Required for comment-summary-in-pr
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
@@ -55,7 +55,7 @@ jobs:
       run:
         shell: bash -eo pipefail {0}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -87,10 +87,10 @@ jobs:
       run:
         shell: bash -eo pipefail {0}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           cache: "npm"
           node-version-file: ".nvmrc"
@@ -119,7 +119,7 @@ jobs:
       run:
         shell: bash -eo pipefail {0}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Discover test files

--- a/.github/workflows/on-pull-request-main.yml
+++ b/.github/workflows/on-pull-request-main.yml
@@ -94,11 +94,13 @@ jobs:
         with:
           cache: "npm"
           node-version-file: ".nvmrc"
-      # Validate lockfile BEFORE npm ci (npx runs without install)
+      # Validate lockfile BEFORE npm ci (committed script, zero network deps)
       - name: Validate lockfile
-        run: npx lockfile-lint --path package-lock.json --type npm --allowed-hosts npm --validate-https
+        run: node scripts/validate-lockfile.mjs
       - name: Install dependencies
-        run: npm ci --prefer-offline --ignore-scripts --no-audit --no-fund
+        run: npm ci --prefer-offline --ignore-scripts --allow-git=none --no-audit --no-fund
+      - name: Check for vulnerabilities
+        run: npm audit --audit-level=high
       - name: Run postinstall
         run: npm run postinstall
       - name: Run prettier

--- a/.github/workflows/sdk-release-publish.yml
+++ b/.github/workflows/sdk-release-publish.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Checkout
         if: steps.check.outputs.should_publish == 'true'
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
@@ -98,12 +98,12 @@ jobs:
       run:
         shell: bash -eo pipefail {0}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           # cache: "npm"  # Disabled — consistent with publish-npm security stance
           node-version-file: ".nvmrc"
@@ -129,12 +129,12 @@ jobs:
         shell: bash -eo pipefail {0}
     steps:
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           # cache: "npm"  # Disabled to prevent cache poisoning in release workflow
           node-version-file: ".nvmrc"
@@ -218,7 +218,7 @@ jobs:
       contents: write # Required for creating releases
     steps:
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/sdk-release-publish.yml
+++ b/.github/workflows/sdk-release-publish.yml
@@ -85,9 +85,38 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Package version: $VERSION"
 
+  # Audit runtime dependencies before publish approval
+  # Runs before the environment gate so maintainers see the result first
+  audit-runtime:
+    needs: check-release
+    if: needs.check-release.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash -eo pipefail {0}
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          # cache: "npm"  # Disabled — consistent with publish-npm security stance
+          node-version-file: ".nvmrc"
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
+      - name: Audit runtime dependencies
+        run: npm audit --workspace=@sealance-io/policy-engine-aleo --omit=dev --omit=peer --audit-level=high
+
   # Publish to npm registry using OIDC (no token required)
   publish-npm:
-    needs: check-release
+    needs: [check-release, audit-runtime]
     if: needs.check-release.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -243,7 +272,7 @@ jobs:
   # Rollup status for tracking
   release-status:
     name: Release Status
-    needs: [check-release, publish-npm, create-release]
+    needs: [check-release, audit-runtime, publish-npm, create-release]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -256,6 +285,7 @@ jobs:
         run: |
           echo "::group::Job Results"
           echo "Should publish: $SHOULD_PUBLISH"
+          echo "Runtime audit: $AUDIT_RESULT"
           echo "npm publish: $NPM_RESULT"
           echo "Release: $RELEASE_RESULT"
           echo "::endgroup::"
@@ -263,6 +293,12 @@ jobs:
           if [[ "$SHOULD_PUBLISH" != "true" ]]; then
             echo "::notice::Not a release PR - skipped publishing"
             exit 0
+          fi
+
+          # Runtime audit must pass
+          if [[ "$AUDIT_RESULT" != "success" ]]; then
+            echo "::error::Runtime dependency audit failed - check for vulnerabilities in SDK dependencies"
+            exit 1
           fi
 
           # npm publish is REQUIRED
@@ -280,5 +316,6 @@ jobs:
           echo "::notice::Release completed successfully (npm + GitHub Release)"
         env:
           SHOULD_PUBLISH: ${{ needs.check-release.outputs.should_publish }}
+          AUDIT_RESULT: ${{ needs.audit-runtime.result }}
           NPM_RESULT: ${{ needs.publish-npm.result }}
           RELEASE_RESULT: ${{ needs.create-release.result }}

--- a/.github/workflows/sdk-release-publish.yml
+++ b/.github/workflows/sdk-release-publish.yml
@@ -109,7 +109,7 @@ jobs:
           node-version-file: ".nvmrc"
 
       - name: Install dependencies
-        run: npm ci --ignore-scripts --no-audit --no-fund
+        run: npm ci --ignore-scripts --allow-git=none --no-audit --no-fund
 
       - name: Audit runtime dependencies
         run: npm audit --workspace=@sealance-io/policy-engine-aleo --omit=dev --omit=peer --audit-level=high
@@ -141,7 +141,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
-        run: npm ci --ignore-scripts --no-audit --no-fund
+        run: npm ci --ignore-scripts --allow-git=none --no-audit --no-fund
 
       - name: Build SDK
         run: npm run build --workspace=@sealance-io/policy-engine-aleo

--- a/.github/workflows/sdk-release-version.yml
+++ b/.github/workflows/sdk-release-version.yml
@@ -52,7 +52,7 @@ jobs:
           node-version-file: ".nvmrc"
 
       - name: Install dependencies
-        run: npm ci --ignore-scripts --no-audit --no-fund
+        run: npm ci --ignore-scripts --allow-git=none --no-audit --no-fund
 
       - name: Create Release Pull Request
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3

--- a/.github/workflows/sdk-release-version.yml
+++ b/.github/workflows/sdk-release-version.yml
@@ -40,14 +40,14 @@ jobs:
           permission-pull-requests: write
 
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: ".nvmrc"
 
@@ -55,7 +55,7 @@ jobs:
         run: npm ci --ignore-scripts --allow-git=none --no-audit --no-fund
 
       - name: Create Release Pull Request
-        uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           title: "chore(release): version packages"
           commit: "chore(release): version packages"

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -26,6 +26,7 @@ jobs:
   #     - ".github/workflows/**"
   #     - ".github/zizmor.yml"
   #     - ".github/dependabot.yml"
+  #     - ".github/dependency-review-config.yml"
   # Workflow-level path filters cause required status checks to remain "Pending"
   # forever when skipped, blocking PR merges. Job-level skipping via `if:` reports
   # "Success" for skipped jobs, allowing the Security Audit Status rollup to pass.
@@ -62,7 +63,7 @@ jobs:
           fi
 
           # Check if workflow files changed
-          WORKFLOW_CHANGES=$(echo "$CHANGED" | grep -E '^\.github/(workflows/|zizmor\.yml|dependabot\.yml)' || echo "")
+          WORKFLOW_CHANGES=$(echo "$CHANGED" | grep -E '^\.github/(workflows/|zizmor\.yml|dependabot\.yml|dependency-review-config\.yml)' || echo "")
 
           if [[ -n "$WORKFLOW_CHANGES" ]]; then
             echo "workflows=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -41,7 +41,7 @@ jobs:
       run:
         shell: bash -eo pipefail {0}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -87,13 +87,13 @@ jobs:
       contents: read
       security-events: write # Required for SARIF upload via advanced-security
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       # Main audit: Upload results to GitHub Advanced Security
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@e639db99335bc9038abc0e066dfcd72e23d26fb4 # v0.3.0
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
         with:
           persona: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'auditor' || 'pedantic' }}
           min-severity: medium
@@ -102,7 +102,7 @@ jobs:
       # PR annotations: Inline comments on changed lines
       - name: Annotate PR
         if: github.event_name == 'pull_request'
-        uses: zizmorcore/zizmor-action@e639db99335bc9038abc0e066dfcd72e23d26fb4 # v0.3.0
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
         with:
           persona: pedantic
           min-severity: medium

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -76,9 +76,6 @@ jobs:
       - name: Install dependencies
         run: npm ci --prefer-offline --ignore-scripts --no-audit --no-fund
 
-      - name: Check for vulnerabilities (production only)
-        run: npm audit --audit-level=high --omit=dev
-
       - name: Run postinstall
         run: npm run postinstall
 

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -34,7 +34,7 @@ jobs:
         shell: bash -eo pipefail {0}
 
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
@@ -58,7 +58,7 @@ jobs:
           CACHE_HIT_BINARY: ${{ steps.setup-leo.outputs.cache-hit-binary }}
           BUILD_TIME_SECONDS: ${{ steps.setup-leo.outputs.build-time-seconds }}
 
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: ".nvmrc"
           cache: "npm"

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -74,7 +74,7 @@ jobs:
       # Note: Lockfile validation happens in caller workflow's linter job
       # Not duplicated here to avoid running with GITHUB_TOKEN in environment
       - name: Install dependencies
-        run: npm ci --prefer-offline --ignore-scripts --no-audit --no-fund
+        run: npm ci --prefer-offline --ignore-scripts --allow-git=none --no-audit --no-fund
 
       - name: Run postinstall
         run: npm run postinstall

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,10 @@ Monorepo for compliant token transfers on Aleo blockchain. Leo programs (smart c
 
 ```bash
 # Setup
-npm ci --ignore-scripts
-npm install -g @sealance-io/dokojs@1.0.7 --ignore-scripts
+npm run lint:lockfile
+npm ci --ignore-scripts --allow-git=none
+npm run postinstall
+npm install -g @sealance-io/dokojs@1.0.8 --ignore-scripts
 
 # Build
 dokojs compile              # Compile Leo programs
@@ -75,7 +77,7 @@ npm run format:fix          # Auto-fix formatting
 2. **Leo Version**: Developed with Leo CLI v4.0.1
 3. **Workspace Rules**: Always install packages from repository root, never in subdirectories
 4. **Sequential Testing**: Integration tests MUST run sequentially (shared chain state in devnode/devnet)
-5. **npm Security**: Always use `--ignore-scripts` for installs (`npm ci`, `npm install`); build/publish workflows may run scripts as needed
+5. **npm Security**: Always use `--ignore-scripts` for installs; use `--allow-git=none` with `npm ci`. Build/publish workflows may run scripts as needed
 6. **Dokojs Patches**: `@doko-js/*` blocked in dependabot - verify against `/patches` before updating
 
 ## CI/CD Status Checks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,9 @@ Monorepo for compliant token transfers on the Aleo blockchain. Leo programs (sma
 
 ```bash
 # Setup
-npm ci --ignore-scripts                              # ALWAYS use --ignore-scripts
+npm run lint:lockfile                                # Explicit lockfile validation
+npm ci --ignore-scripts --allow-git=none            # ALWAYS use --ignore-scripts
+npm run postinstall                                 # Apply committed patches explicitly
 npm install -g @sealance-io/dokojs@1.0.8 --ignore-scripts
 
 # Build
@@ -58,7 +60,7 @@ npm run deploy:testnet
 
 ## Constraints
 
-- **npm security**: Always `--ignore-scripts` for install/ci commands
+- **npm security**: Always `--ignore-scripts` for install/ci commands and use `--allow-git=none` with `npm ci`
 - **Workspace**: Install packages from repo root only, never in subdirectories
 - **Leo version**: v4.0.1 — compile with `dokojs compile`, not `leo build`
 - **dokojs patches**: `@doko-js/*` is patched locally — verify against `/patches` before updating

--- a/README.md
+++ b/README.md
@@ -79,8 +79,10 @@ This repository uses [npm workspaces](https://docs.npmjs.com/cli/using-npm/works
    # Navigate to repository root
    cd compliant-transfer-aleo
 
-   # Install all dependencies (root + SDK workspace)
-   npm ci --ignore-scripts
+   # Validate lockfile, install all dependencies, then apply committed patches
+   npm run lint:lockfile
+   npm ci --ignore-scripts --allow-git=none
+   npm run postinstall
    ```
 
    **Note**: Do not run `npm install` in workspace directories (`packages/*/`). The root workspace manages all dependencies and ensures consistent versions across packages.

--- a/docs/DEPENDABOT-STRATEGY.md
+++ b/docs/DEPENDABOT-STRATEGY.md
@@ -85,8 +85,8 @@ Since SHA-pinned actions don't receive automatic security alerts:
 
 Dependabot is one layer in defense-in-depth:
 
-1. **Install** - `npm ci --ignore-scripts` (deterministic, safe)
-2. **Validate** - `lockfile-lint` (registry sources, HTTPS)
+1. **Install** - `npm ci --ignore-scripts --allow-git=none` (deterministic, safe)
+2. **Validate** - `node scripts/validate-lockfile.mjs` (registry sources, HTTPS, integrity presence)
 3. **Gate** - `dependency-review-action` (PR diff, high+ vulnerabilities)
 4. **Update** - Dependabot (automated with cooldowns)
 5. **Review** - Human approval before merge

--- a/docs/DEPENDABOT-STRATEGY.md
+++ b/docs/DEPENDABOT-STRATEGY.md
@@ -87,7 +87,7 @@ Dependabot is one layer in defense-in-depth:
 
 1. **Install** - `npm ci --ignore-scripts` (deterministic, safe)
 2. **Validate** - `lockfile-lint` (registry sources, HTTPS)
-3. **Scan** - `npm audit` (known vulnerabilities)
+3. **Gate** - `dependency-review-action` (PR diff, high+ vulnerabilities)
 4. **Update** - Dependabot (automated with cooldowns)
 5. **Review** - Human approval before merge
 6. **Audit** - `zizmor` (weekly workflow security)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -6,7 +6,9 @@ Commands and workflows for developing in this repository.
 
 ```bash
 # Install from repository root (uses npm workspaces)
-npm ci --ignore-scripts
+npm run lint:lockfile
+npm ci --ignore-scripts --allow-git=none
+npm run postinstall
 
 # Install doko-js CLI (required for compiling Leo programs)
 npm install -g @sealance-io/dokojs@1.0.8 --ignore-scripts

--- a/docs/NPM-SECURITY.md
+++ b/docs/NPM-SECURITY.md
@@ -7,30 +7,33 @@ Security practices based on [Liran Tal's npm Security Best Practices](https://gi
 ### 1. Deterministic Installation
 
 ```bash
-npm ci --prefer-offline --ignore-scripts --no-audit --no-fund
+npm ci --prefer-offline --ignore-scripts --allow-git=none --no-audit --no-fund
 ```
 
 - Enforces strict lockfile adherence
+- Blocks git dependency fetches during install
 - Aborts if `package.json` / `package-lock.json` are out of sync
 - Clean `node_modules` state on each install
 
 ### 2. Post-Install Script Protection
 
 ```bash
-npm ci --ignore-scripts      # Install without running scripts
+npm ci --ignore-scripts --allow-git=none  # Install without running scripts
 npm run postinstall          # Controlled execution after validation
 ```
 
-**Why not `.npmrc` with `ignore-scripts=true`?** Our `preinstall` hook validates the lockfile and `postinstall` applies required patches. CI uses explicit flags; local dev benefits from automatic execution after validation.
+**Why not `.npmrc` with `ignore-scripts=true`?** This repo treats lockfile validation as an explicit step (`npm run lint:lockfile`) and applies patches via an explicit `npm run postinstall` after install. CI and any `npm ci --ignore-scripts` flow must run those commands directly because lifecycle scripts are skipped.
 
 ### 3. Lockfile Validation
 
 ```bash
 npm run lint:lockfile
-# or: npx lockfile-lint --path package-lock.json --type npm --allowed-hosts npm --validate-https
+# or: node scripts/validate-lockfile.mjs
 ```
 
-Validates: npm registry only, HTTPS enforcement, SHA-512 integrity hashes.
+Committed validator with no registry bootstrap. Validates: npm registry only,
+HTTPS enforcement, integrity presence for resolved packages, and rejection of
+git/file/tarball fallback sources when `resolved` is absent.
 
 ### 4. Vulnerability Scanning
 
@@ -43,19 +46,20 @@ Validates: npm registry only, HTTPS enforcement, SHA-512 integrity hashes.
 ## CI Workflow
 
 ```yaml
-- run: npx lockfile-lint --path package-lock.json --type npm --allowed-hosts npm --validate-https
-- run: npm ci --prefer-offline --ignore-scripts --no-audit --no-fund
+- run: node scripts/validate-lockfile.mjs
+- run: npm ci --prefer-offline --ignore-scripts --allow-git=none --no-audit --no-fund
 - run: npm run postinstall
 ```
 
 ## Attack Prevention
 
-| Attack                 | Prevention                                                |
-| ---------------------- | --------------------------------------------------------- |
-| Malicious post-install | `--ignore-scripts` blocks automatic execution             |
-| Lockfile poisoning     | `lockfile-lint` validates registry URLs                   |
-| Dependency confusion   | Lockfile validation + registry restrictions               |
-| Compromised update     | Lockfile pinning + `dependency-review-action` + PR review |
+| Attack                   | Prevention                                                |
+| ------------------------ | --------------------------------------------------------- |
+| Malicious post-install   | `--ignore-scripts` blocks automatic execution             |
+| Lockfile poisoning       | Committed validator enforces registry-only URLs + HTTPS   |
+| Git dependency injection | `--allow-git=none` blocks git fetches during install      |
+| Dependency confusion     | Lockfile validation + install policy restrictions         |
+| Compromised update       | Lockfile pinning + `dependency-review-action` + PR review |
 
 ## Dependabot Cooldowns
 
@@ -69,27 +73,29 @@ Security updates bypass all cooldowns. See `.github/dependabot.yml` and `docs/DE
 
 ## Tooling Status
 
-| Tool                       | Purpose                    | Status               |
-| -------------------------- | -------------------------- | -------------------- |
-| `npm ci`                   | Deterministic installation | Active               |
-| `--ignore-scripts`         | Block post-install scripts | Active               |
-| `lockfile-lint`            | Lockfile validation        | Active               |
-| `npm audit`                | Vulnerability scanning     | Publish gate + local |
-| `dependency-review-action` | PR vulnerability gating    | Active               |
-| `zizmor`                   | Workflow security          | Active               |
-| Dependabot                 | Automated updates          | Active               |
-| npm provenance             | Build attestations         | Planned              |
-| OIDC publishing            | Token-less publishing      | Planned              |
+| Tool                            | Purpose                      | Status               |
+| ------------------------------- | ---------------------------- | -------------------- |
+| `npm ci`                        | Deterministic installation   | Active               |
+| `--ignore-scripts`              | Block post-install scripts   | Active               |
+| `--allow-git=none`              | Block git dependency fetches | Active               |
+| `scripts/validate-lockfile.mjs` | Lockfile validation          | Active               |
+| `npm audit`                     | Vulnerability scanning       | Publish gate + local |
+| `dependency-review-action`      | PR vulnerability gating      | Active               |
+| `zizmor`                        | Workflow security            | Active               |
+| Dependabot                      | Automated updates            | Active               |
+| npm provenance                  | Build attestations           | Planned              |
+| OIDC publishing                 | Token-less publishing        | Planned              |
 
 ## Incident Response
 
 1. Review `npm audit` output and check if affected version is in lockfile
 2. Update to patched version or remove dependency
-3. Run `lockfile-lint` to verify clean state
+3. Run `npm run lint:lockfile` to verify clean state
 4. Document and adjust practices as needed
 
 ## References
 
 - [npm Security Best Practices](https://github.com/lirantal/npm-security-best-practices)
-- [lockfile-lint](https://github.com/lirantal/lockfile-lint)
+- [npm `allow-git`](https://docs.npmjs.com/cli/v11/using-npm/config#allow-git)
+- [npm `package-lock.json`](https://docs.npmjs.com/cli/v10/configuring-npm/package-lock-json/)
 - [npm provenance](https://docs.npmjs.com/generating-provenance-statements)

--- a/docs/NPM-SECURITY.md
+++ b/docs/NPM-SECURITY.md
@@ -34,10 +34,11 @@ Validates: npm registry only, HTTPS enforcement, SHA-512 integrity hashes.
 
 ### 4. Vulnerability Scanning
 
-| Environment | Command                            | Threshold |
-| ----------- | ---------------------------------- | --------- |
-| CI (PR)     | `dependency-review-action`         | High+     |
-| Local       | `npm audit --audit-level=moderate` | Moderate+ |
+| Environment  | Command                                    | Threshold |
+| ------------ | ------------------------------------------ | --------- |
+| CI (PR)      | `dependency-review-action`                 | High+     |
+| CI (publish) | `npm audit` (SDK workspace, omit dev+peer) | High+     |
+| Local        | `npm audit --audit-level=moderate`         | Moderate+ |
 
 ## CI Workflow
 
@@ -68,17 +69,17 @@ Security updates bypass all cooldowns. See `.github/dependabot.yml` and `docs/DE
 
 ## Tooling Status
 
-| Tool                       | Purpose                    | Status     |
-| -------------------------- | -------------------------- | ---------- |
-| `npm ci`                   | Deterministic installation | Active     |
-| `--ignore-scripts`         | Block post-install scripts | Active     |
-| `lockfile-lint`            | Lockfile validation        | Active     |
-| `npm audit`                | Vulnerability scanning     | Local only |
-| `dependency-review-action` | PR vulnerability gating    | Active     |
-| `zizmor`                   | Workflow security          | Active     |
-| Dependabot                 | Automated updates          | Active     |
-| npm provenance             | Build attestations         | Planned    |
-| OIDC publishing            | Token-less publishing      | Planned    |
+| Tool                       | Purpose                    | Status               |
+| -------------------------- | -------------------------- | -------------------- |
+| `npm ci`                   | Deterministic installation | Active               |
+| `--ignore-scripts`         | Block post-install scripts | Active               |
+| `lockfile-lint`            | Lockfile validation        | Active               |
+| `npm audit`                | Vulnerability scanning     | Publish gate + local |
+| `dependency-review-action` | PR vulnerability gating    | Active               |
+| `zizmor`                   | Workflow security          | Active               |
+| Dependabot                 | Automated updates          | Active               |
+| npm provenance             | Build attestations         | Planned              |
+| OIDC publishing            | Token-less publishing      | Planned              |
 
 ## Incident Response
 

--- a/docs/NPM-SECURITY.md
+++ b/docs/NPM-SECURITY.md
@@ -36,7 +36,7 @@ Validates: npm registry only, HTTPS enforcement, SHA-512 integrity hashes.
 
 | Environment | Command                            | Threshold |
 | ----------- | ---------------------------------- | --------- |
-| CI          | `npm audit --audit-level=high`     | High+     |
+| CI (PR)     | `dependency-review-action`         | High+     |
 | Local       | `npm audit --audit-level=moderate` | Moderate+ |
 
 ## CI Workflow
@@ -44,18 +44,17 @@ Validates: npm registry only, HTTPS enforcement, SHA-512 integrity hashes.
 ```yaml
 - run: npx lockfile-lint --path package-lock.json --type npm --allowed-hosts npm --validate-https
 - run: npm ci --prefer-offline --ignore-scripts --no-audit --no-fund
-- run: npm audit --audit-level=high
 - run: npm run postinstall
 ```
 
 ## Attack Prevention
 
-| Attack                 | Prevention                                    |
-| ---------------------- | --------------------------------------------- |
-| Malicious post-install | `--ignore-scripts` blocks automatic execution |
-| Lockfile poisoning     | `lockfile-lint` validates registry URLs       |
-| Dependency confusion   | Lockfile validation + registry restrictions   |
-| Compromised update     | Lockfile pinning + `npm audit` + PR review    |
+| Attack                 | Prevention                                                |
+| ---------------------- | --------------------------------------------------------- |
+| Malicious post-install | `--ignore-scripts` blocks automatic execution             |
+| Lockfile poisoning     | `lockfile-lint` validates registry URLs                   |
+| Dependency confusion   | Lockfile validation + registry restrictions               |
+| Compromised update     | Lockfile pinning + `dependency-review-action` + PR review |
 
 ## Dependabot Cooldowns
 
@@ -69,17 +68,17 @@ Security updates bypass all cooldowns. See `.github/dependabot.yml` and `docs/DE
 
 ## Tooling Status
 
-| Tool                       | Purpose                    | Status  |
-| -------------------------- | -------------------------- | ------- |
-| `npm ci`                   | Deterministic installation | Active  |
-| `--ignore-scripts`         | Block post-install scripts | Active  |
-| `lockfile-lint`            | Lockfile validation        | Active  |
-| `npm audit`                | Vulnerability scanning     | Active  |
-| `dependency-review-action` | PR vuln + license gating   | Active  |
-| `zizmor`                   | Workflow security          | Active  |
-| Dependabot                 | Automated updates          | Active  |
-| npm provenance             | Build attestations         | Planned |
-| OIDC publishing            | Token-less publishing      | Planned |
+| Tool                       | Purpose                    | Status     |
+| -------------------------- | -------------------------- | ---------- |
+| `npm ci`                   | Deterministic installation | Active     |
+| `--ignore-scripts`         | Block post-install scripts | Active     |
+| `lockfile-lint`            | Lockfile validation        | Active     |
+| `npm audit`                | Vulnerability scanning     | Local only |
+| `dependency-review-action` | PR vulnerability gating    | Active     |
+| `zizmor`                   | Workflow security          | Active     |
+| Dependabot                 | Automated updates          | Active     |
+| npm provenance             | Build attestations         | Planned    |
+| OIDC publishing            | Token-less publishing      | Planned    |
 
 ## Incident Response
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -353,7 +353,9 @@ git clone https://github.com/sealance-io/compliant-transfer-aleo.git
 cd compliant-transfer-aleo
 
 # 2. Install and build
-npm ci
+npm run lint:lockfile
+npm ci --ignore-scripts --allow-git=none
+npm run postinstall
 npm run build --workspace=@sealance-io/policy-engine-aleo
 
 # 3. Login to npm (requires 2FA)

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -236,13 +236,15 @@ When reviewing PRs that modify the SDK:
 
 2. **Review & Merge**: Maintainer reviews the version bumps and CHANGELOG updates, then merges
 
-3. **Approval Required**: When the release PR is merged, the resulting `push` to `main` triggers `sdk-release-publish.yml`, which then pauses for admin approval (GitHub environment protection)
+3. **Audit + Approval**: When the release PR is merged, the resulting `push` to `main` triggers `sdk-release-publish.yml`:
+   - Runtime dependency audit runs automatically (blocks on high/critical vulns in `@scure/base` tree)
+   - If audit passes, workflow pauses for admin approval (GitHub environment protection)
 
 4. **Publish**: After approval:
    - Package is published to npm via OIDC (with provenance and retry logic)
    - GitHub Release is created with tag (idempotent - safe to re-run)
 
-If the publish workflow itself was broken at merge time, maintainers can run `sdk-release-publish.yml` manually from `main` after the workflow fix lands. The same `npm-publish` environment approval still applies.
+If the audit blocks a release, fix the vulnerable dependency, merge to main, then manually dispatch `sdk-release-publish.yml`. If the publish workflow itself was broken at merge time, the same manual dispatch path applies. The `npm-publish` environment approval still applies in both cases.
 
 ### Pre-release Versions (Alpha/Beta/RC)
 

--- a/docs/SECURITY-WORKFLOWS.md
+++ b/docs/SECURITY-WORKFLOWS.md
@@ -68,10 +68,11 @@ concurrency:
 
 ### 9. Dependency Scanning
 
-| Tool                       | Scope         | When       |
-| -------------------------- | ------------- | ---------- |
-| `dependency-review-action` | PR diff only  | PR gate    |
-| `npm audit`                | Full lockfile | Local only |
+| Tool                                       | Scope             | When         |
+| ------------------------------------------ | ----------------- | ------------ |
+| `dependency-review-action`                 | PR diff only      | PR gate      |
+| `npm audit` (SDK workspace, omit dev+peer) | Runtime deps only | Publish gate |
+| `npm audit`                                | Full lockfile     | Local only   |
 
 Blocked licenses: GPL-2.0, GPL-3.0, AGPL (checked manually via `npm run lint:licenses`; dependency-review license checking planned).
 

--- a/docs/SECURITY-WORKFLOWS.md
+++ b/docs/SECURITY-WORKFLOWS.md
@@ -16,7 +16,7 @@ All workflows pass zizmor audits (regular, pedantic, auditor modes). Weekly scan
 permissions: {} # workflow-level default
 ```
 
-Job-level permissions: `contents: read` (standard), `security-events: write` (SARIF upload), `packages: read` (GHCR pulls).
+Job-level permissions: `contents: read` (standard), `security-events: write` (SARIF upload), `packages: read` (GHCR pulls), `pull-requests: write` (dependency-review PR comment).
 
 ### 2. Action Pinning
 
@@ -26,7 +26,7 @@ All actions pinned to commit SHAs:
 | ---------------------------------- | ---------- | ------- |
 | `actions/checkout`                 | `8e8c483d` | v6.0.1  |
 | `actions/create-github-app-token`  | `f8d387b6` | v3.0.0  |
-| `actions/dependency-review-action` | `3c4e3dcb` | v4.8.2  |
+| `actions/dependency-review-action` | `2031cfc0` | v4.9.0  |
 | `actions/github-script`            | `ed597411` | v8.0.0  |
 | `actions/setup-node`               | `6044e13b` | v6.2.0  |
 | `changesets/action`                | `e0145edc` | v1.5.3  |
@@ -68,12 +68,12 @@ concurrency:
 
 ### 9. Dependency Scanning
 
-| Tool                       | Scope         | When          |
-| -------------------------- | ------------- | ------------- |
-| `npm audit`                | Full lockfile | After install |
-| `dependency-review-action` | PR diff only  | PR gate       |
+| Tool                       | Scope         | When       |
+| -------------------------- | ------------- | ---------- |
+| `dependency-review-action` | PR diff only  | PR gate    |
+| `npm audit`                | Full lockfile | Local only |
 
-Blocked licenses: GPL-2.0, GPL-3.0, AGPL (incompatible with Apache-2.0).
+Blocked licenses: GPL-2.0, GPL-3.0, AGPL (checked manually via `npm run lint:licenses`; dependency-review license checking planned).
 
 ## Action Trust Levels
 

--- a/docs/SECURITY-WORKFLOWS.md
+++ b/docs/SECURITY-WORKFLOWS.md
@@ -24,14 +24,14 @@ All actions pinned to commit SHAs:
 
 | Action                             | SHA        | Version |
 | ---------------------------------- | ---------- | ------- |
-| `actions/checkout`                 | `8e8c483d` | v6.0.1  |
+| `actions/checkout`                 | `de0fac2e` | v6.0.2  |
 | `actions/create-github-app-token`  | `f8d387b6` | v3.0.0  |
 | `actions/dependency-review-action` | `2031cfc0` | v4.9.0  |
 | `actions/github-script`            | `ed597411` | v8.0.0  |
-| `actions/setup-node`               | `6044e13b` | v6.2.0  |
-| `changesets/action`                | `e0145edc` | v1.5.3  |
+| `actions/setup-node`               | `53b83947` | v6.3.0  |
+| `changesets/action`                | `6a0a831f` | v1.7.0  |
 | `sealance-io/setup-leo-action`     | `4491779e` | v1.1.0  |
-| `zizmorcore/zizmor-action`         | `e639db99` | v0.3.0  |
+| `zizmorcore/zizmor-action`         | `71321a20` | v0.5.2  |
 
 ### 3. Container Image Pinning
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2574,9 +2574,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3313,15 +3313,15 @@
       "license": "MIT"
     },
     "node_modules/editorconfig": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.4.tgz",
-      "integrity": "sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+      "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@one-ini/wasm": "0.1.1",
         "commander": "^10.0.0",
-        "minimatch": "9.0.1",
+        "minimatch": "^9.0.1",
         "semver": "^7.5.3"
       },
       "bin": {
@@ -3821,45 +3821,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/glob/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
-      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globby": {
@@ -4860,13 +4821,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
-      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -5565,9 +5526,9 @@
       }
     },
     "node_modules/readdir-glob/node_modules/minimatch": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.7.tgz",
-      "integrity": "sha512-FjiwU9HaHW6YB3H4a1sFudnv93lvydNjz2lmyUXR6IwKhGI+bgL3SOZrBGn6kvvX2pJvhEkGSGjyTHN47O4rqA==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5659,9 +5620,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5700,13 +5661,13 @@
       }
     },
     "node_modules/rimraf/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -6944,9 +6905,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "test"
   },
   "scripts": {
-    "preinstall": "npx lockfile-lint --path package-lock.json --type npm --allowed-hosts npm --validate-https",
+    "lint:lockfile": "node scripts/validate-lockfile.mjs",
     "postinstall": "patch-package",
     "changeset": "changeset",
     "version": "changeset version",

--- a/scripts/validate-lockfile.mjs
+++ b/scripts/validate-lockfile.mjs
@@ -1,0 +1,63 @@
+/**
+ * Committed, zero-dependency lockfile validator.
+ *
+ * Checks that every resolved URL in package-lock.json points to the npm
+ * registry over HTTPS, requires integrity for resolved packages, and rejects
+ * non-registry sources encoded in `version` when `resolved` is absent.
+ *
+ * Runs as an explicit validation step before `npm ci` without bootstrapping
+ * any package from the registry.
+ */
+
+import { readFileSync } from "node:fs";
+
+const ALLOWED_PREFIX = "https://registry.npmjs.org/";
+const SEMVER_REGEXP =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+
+const raw = readFileSync("package-lock.json", "utf8");
+const lock = JSON.parse(raw);
+
+if (!lock.lockfileVersion || lock.lockfileVersion < 2) {
+  console.error(`Lockfile version ${lock.lockfileVersion ?? "missing"} is unsupported (requires >= 2)`);
+  process.exit(1);
+}
+
+const packages = lock.packages ?? {};
+const violations = [];
+
+for (const [name, info] of Object.entries(packages)) {
+  // Skip root package and workspace links
+  if (!name || info.link) continue;
+
+  const { resolved, integrity, version } = info;
+
+  // Validate resolved URL if present.
+  if (resolved) {
+    if (!resolved.startsWith(ALLOWED_PREFIX)) {
+      violations.push(`${name}: resolved URL not on npm registry: ${resolved}`);
+    }
+  }
+
+  // When resolved is absent, version may encode a non-registry source
+  // (tarball URL, git URL, file: path, etc.). Only valid semver versions
+  // are safe — reject anything else to match the repo's registry-only policy.
+  if (!resolved && version && !SEMVER_REGEXP.test(version)) {
+    violations.push(`${name}: non-registry source in version: ${version}`);
+  }
+
+  if (resolved && !integrity) {
+    violations.push(`${name}: missing integrity hash`);
+  }
+}
+
+if (violations.length > 0) {
+  console.error("Lockfile validation failed:\n");
+  for (const v of violations) {
+    console.error(`  ✗ ${v}`);
+  }
+  console.error(`\n${violations.length} violation(s) found.`);
+  process.exit(1);
+}
+
+console.log(`Lockfile OK: ${Object.keys(packages).length} packages validated.`);

--- a/scripts/validate-lockfile.test.mjs
+++ b/scripts/validate-lockfile.test.mjs
@@ -1,0 +1,236 @@
+/**
+ * Self-contained tests for validate-lockfile.mjs.
+ * No test framework needed — uses Node.js built-in assert.
+ *
+ * Run: node scripts/validate-lockfile.test.mjs
+ */
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = join(__dirname, "validate-lockfile.mjs");
+
+function run(lockfileContent) {
+  // Each test gets an isolated temp directory so the real lockfile is never
+  // modified, even if the process exits unexpectedly.
+  const dir = mkdtempSync(join(tmpdir(), "validate-lockfile-"));
+  const path = join(dir, "package-lock.json");
+
+  try {
+    writeFileSync(path, JSON.stringify(lockfileContent, null, 2));
+    const output = execFileSync("node", [SCRIPT], {
+      cwd: dir,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return { exitCode: 0, stdout: output, stderr: "" };
+  } catch (err) {
+    return {
+      exitCode: err.status,
+      stdout: err.stdout ?? "",
+      stderr: err.stderr ?? "",
+    };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ─── Test 1: Current lockfile passes validation ─────────────────────────────
+console.log("Test 1: Current lockfile passes validation...");
+const result1 = execFileSync("node", [SCRIPT], {
+  encoding: "utf8",
+  stdio: ["pipe", "pipe", "pipe"],
+});
+assert.match(result1, /Lockfile OK/);
+console.log("  PASS");
+
+// ─── Test 2: Rejects non-npm registry URL ───────────────────────────────────
+console.log("Test 2: Rejects non-npm registry URL...");
+const result2 = run({
+  lockfileVersion: 3,
+  packages: {
+    "": { name: "test-root" },
+    "node_modules/evil-pkg": {
+      resolved: "https://evil.example.com/evil-pkg-1.0.0.tgz",
+      integrity: "sha512-abc123==",
+    },
+  },
+});
+assert.equal(result2.exitCode, 1);
+assert.match(result2.stderr, /not on npm registry/);
+assert.match(result2.stderr, /evil\.example\.com/);
+console.log("  PASS");
+
+// ─── Test 3: Rejects missing integrity hash ─────────────────────────────────
+console.log("Test 3: Rejects missing integrity hash...");
+const result3 = run({
+  lockfileVersion: 3,
+  packages: {
+    "": { name: "test-root" },
+    "node_modules/no-integrity": {
+      resolved: "https://registry.npmjs.org/no-integrity/-/no-integrity-1.0.0.tgz",
+    },
+  },
+});
+assert.equal(result3.exitCode, 1);
+assert.match(result3.stderr, /missing integrity/);
+console.log("  PASS");
+
+// ─── Test 4: Skips root package and workspace links ─────────────────────────
+console.log("Test 4: Skips root package and workspace links...");
+const result4 = run({
+  lockfileVersion: 3,
+  packages: {
+    "": { name: "my-monorepo", version: "1.0.0" },
+    "packages/my-sdk": { link: true },
+    "node_modules/valid-pkg": {
+      resolved: "https://registry.npmjs.org/valid-pkg/-/valid-pkg-1.0.0.tgz",
+      integrity: "sha512-validhash==",
+    },
+  },
+});
+assert.equal(result4.exitCode, 0);
+assert.match(result4.stdout, /Lockfile OK/);
+console.log("  PASS");
+
+// ─── Test 5: Rejects unsupported lockfile version ───────────────────────────
+console.log("Test 5: Rejects unsupported lockfile version...");
+const result5 = run({
+  lockfileVersion: 1,
+  packages: {},
+});
+assert.equal(result5.exitCode, 1);
+assert.match(result5.stderr, /unsupported/);
+console.log("  PASS");
+
+// ─── Test 6: Reports multiple violations ────────────────────────────────────
+console.log("Test 6: Reports multiple violations...");
+const result6 = run({
+  lockfileVersion: 3,
+  packages: {
+    "": { name: "test-root" },
+    "node_modules/bad-url": {
+      resolved: "http://registry.npmjs.org/bad-url/-/bad-url-1.0.0.tgz",
+      integrity: "sha512-abc==",
+    },
+    "node_modules/no-hash": {
+      resolved: "https://registry.npmjs.org/no-hash/-/no-hash-1.0.0.tgz",
+    },
+  },
+});
+assert.equal(result6.exitCode, 1);
+assert.match(result6.stderr, /2 violation/);
+console.log("  PASS");
+
+// ─── Test 7: Rejects tarball URL in version field (no resolved) ─────────────
+console.log("Test 7: Rejects tarball URL in version field when resolved is absent...");
+const result7 = run({
+  lockfileVersion: 3,
+  packages: {
+    "": { name: "test-root" },
+    "node_modules/evil-tarball": {
+      version: "http://evil.example.com/evil-tarball-1.0.0.tgz",
+    },
+  },
+});
+assert.equal(result7.exitCode, 1);
+assert.match(result7.stderr, /non-registry source/);
+console.log("  PASS");
+
+// ─── Test 8: Rejects git URL in version field ──────────────────────────────
+console.log("Test 8: Rejects git URL in version field...");
+const result8 = run({
+  lockfileVersion: 3,
+  packages: {
+    "": { name: "test-root" },
+    "node_modules/git-dep": {
+      version: "git+https://github.com/attacker/repo.git#main",
+    },
+  },
+});
+assert.equal(result8.exitCode, 1);
+assert.match(result8.stderr, /non-registry source/);
+console.log("  PASS");
+
+// ─── Test 9: Allows semver version string (not a URL) ──────────────────────
+console.log("Test 9: Allows normal semver version without resolved (bundled dep)...");
+const result9 = run({
+  lockfileVersion: 3,
+  packages: {
+    "": { name: "test-root" },
+    "node_modules/bundled-dep": {
+      version: "1.2.3",
+    },
+  },
+});
+assert.equal(result9.exitCode, 0);
+assert.match(result9.stdout, /Lockfile OK/);
+console.log("  PASS");
+
+// ─── Test 10: Rejects file: path in version field ──────────────────────────
+console.log("Test 10: Rejects file: path in version field...");
+const result10 = run({
+  lockfileVersion: 3,
+  packages: {
+    "": { name: "test-root" },
+    "node_modules/local-evil": {
+      version: "file:../evil.tgz",
+    },
+  },
+});
+assert.equal(result10.exitCode, 1);
+assert.match(result10.stderr, /non-registry source/);
+assert.match(result10.stderr, /file:\.\.\/evil\.tgz/);
+console.log("  PASS");
+
+// ─── Test 11: Allows semver with pre-release/build metadata ────────────────
+console.log("Test 11: Allows semver with pre-release metadata...");
+const result11 = run({
+  lockfileVersion: 3,
+  packages: {
+    "": { name: "test-root" },
+    "node_modules/prerelease-dep": {
+      version: "2.0.0-beta.1+build.123",
+    },
+  },
+});
+assert.equal(result11.exitCode, 0);
+assert.match(result11.stdout, /Lockfile OK/);
+console.log("  PASS");
+
+// ─── Test 12: Rejects semver-like string with trailing path ─────────────────
+console.log("Test 12: Rejects semver-like string with trailing non-semver content...");
+const result12 = run({
+  lockfileVersion: 3,
+  packages: {
+    "": { name: "test-root" },
+    "node_modules/tricky-dep": {
+      version: "1.0.0 || file:../evil.tgz",
+    },
+  },
+});
+assert.equal(result12.exitCode, 1);
+assert.match(result12.stderr, /non-registry source/);
+console.log("  PASS");
+
+// ─── Test 13: Rejects semver with leading zeros ─────────────────────────────
+console.log("Test 13: Rejects semver with leading zeros...");
+const result13 = run({
+  lockfileVersion: 3,
+  packages: {
+    "": { name: "test-root" },
+    "node_modules/leading-zero-dep": {
+      version: "01.2.3",
+    },
+  },
+});
+assert.equal(result13.exitCode, 1);
+assert.match(result13.stderr, /non-registry source/);
+console.log("  PASS");
+
+console.log("\nAll tests passed.");


### PR DESCRIPTION
### Summary                                                                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                          
  - **Replace `lockfile-lint` with a committed, zero-dependency lockfile validator** (`scripts/validate-lockfile.mjs`) — eliminates bootstrapping any package from the registry before validation. Includes 13 self-contained tests.                                                                                                                                      
  - **Add `--allow-git=none` to all `npm ci` calls** — blocks git dependency fetches during install, closing a supply-chain vector.
  - **Centralize dependency-review config** into `.github/dependency-review-config.yml` — both PR workflows share one config, preventing drift. Upgraded to `dependency-review-action` v4.9.0 with PR comment summaries.                                                                                                                                                  
  - **Add SDK release audit gate** — new `audit-runtime` job in `sdk-release-publish.yml` audits runtime deps before the environment approval step.                                                                                                                                                                                                                       
  - **Refresh all pinned GitHub Actions** — checkout v6.0.2, setup-node v6.3.0, changesets/action v1.7.0, zizmor-action v0.5.2.                                                                                                                                                                                                                                           
  - **`npm audit fix`** — bumps minimatch, brace-expansion, editorconfig, yaml to latest patches; removes a nested glob duplicate subtree.                                                                                                                                                                                                                                
  - **Docs updated** across 7 files to reflect the new install policy and tooling.                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                          
  ### Key changes by area                                                                                                                                                                                                                                                                                                                                                 
                  
  | Area | Files | What changed |                                                                                                                                                                                                                                                                                                                                         
  |------|-------|--------------|
  | New tooling | `scripts/validate-lockfile.mjs`, `.test.mjs` | Zero-dep lockfile validator + tests |
  | CI config | `.github/dependency-review-config.yml` | Shared dep-review config (new file) |
  | Workflows | 8 workflow YAML files | Pin bumps, `--allow-git=none`, centralized dep-review, audit gate |                                                                                                                                                                                                                                                               
  | Install policy | `package.json` | `preinstall` hook → explicit `lint:lockfile` script |
  | Lockfile | `package-lock.json` | `npm audit fix` patch bumps |                                                                                                                                                                                                                                                                                                        
  | Docs | 7 doc/config files | Reflect new security posture |
                                                                                                                                                                                                                                                                                                                                                                          
  ### Risks / things to verify                                                                                                                                                                                                                                                                                                                                            
   
  - The `preinstall` hook was removed — lockfile validation is now an explicit step (`npm run lint:lockfile`). Developers must run it manually or rely on CI.                                                                                                                                                                                                             
  - `pull-requests: write` added to dependency-review jobs for PR comment summaries — expected and scoped.
  - Test jobs now depend on `dependency-review` completing — adds a gate, may slightly increase PR wall-clock time.                                                                                                                                                                                                                                                       
  - `npm audit` removed from `test-runner.yml` — scanning now handled at PR gate (dependency-review-action) and publish gate (audit-runtime job) instead of per-test-run.