### PR TITLE
Guard random address generation against Leo CLI type-suffix misparsing

### DIFF
--- a/test/compliant_token.test.ts
+++ b/test/compliant_token.test.ts
@@ -19,7 +19,8 @@ import {
 import { getLeafIndices, getSiblingPath } from "../lib/FreezeList";
 import { fundWithCredits } from "../lib/Fund";
 import { deployIfNotDeployed } from "../lib/Deploy";
-import { Account, AleoNetworkClient } from "@provablehq/sdk";
+import { AleoNetworkClient } from "@provablehq/sdk";
+import { safeAddress } from "./utils/Accounts";
 import { decryptToken } from "../artifacts/js/leo2js/compliant_token_template";
 import { Token } from "../artifacts/js/types/compliant_token_template";
 import { Credentials } from "../artifacts/js/types/compliant_token_template";
@@ -677,7 +678,7 @@ describe("test compliant token program", () => {
     // It's impossible to get the credentials record with an invalid merkle proof
     await expect(tokenContractForFrozenAccount.get_credentials(frozenAccountMerkleProof)).rejects.toThrow();
 
-    const randomAddress = new Account().address().to_string();
+    const randomAddress = safeAddress();
     const leaves = generateLeaves([randomAddress]);
     const tree = buildTree(leaves);
     const senderLeafIndices = getLeafIndices(tree, account);

--- a/test/freeze_registry.test.ts
+++ b/test/freeze_registry.test.ts
@@ -19,7 +19,7 @@ import { getLeafIndices, getSiblingPath } from "../lib/FreezeList";
 import { fundWithCredits } from "../lib/Fund";
 import { deployIfNotDeployed } from "../lib/Deploy";
 import { buildTree, generateLeaves } from "@sealance-io/policy-engine-aleo";
-import { Account } from "@provablehq/sdk";
+import { safeAddress } from "./utils/Accounts";
 import { isProgramInitialized } from "../lib/Initalize";
 import { Sealance_freezelist_registryContract } from "../artifacts/js/sealance_freezelist_registry";
 import { Multisig_coreContract } from "../artifacts/js/multisig_core";
@@ -223,7 +223,7 @@ describe("test freeze registry program", () => {
     );
     await expect(rejectedTx.wait()).rejects.toThrow();
 
-    let randomAddress = new Account().address().to_string();
+    let randomAddress = safeAddress();
     let tx = await freezeRegistryContractForFreezeListManager.update_freeze_list(randomAddress, true, 2, root, root);
     await tx.wait();
     isAccountFrozen = await freezeRegistryContract.freeze_list(randomAddress);
@@ -234,7 +234,7 @@ describe("test freeze registry program", () => {
     expect(frozenAccountByIndex).toBe(randomAddress);
     expect(lastIndex).toBe(2);
 
-    randomAddress = new Account().address().to_string();
+    randomAddress = safeAddress();
     // Cannot freeze an account when the frozen list index is greater than the last index
     rejectedTx = await freezeRegistryContractForFreezeListManager.update_freeze_list(
       randomAddress,

--- a/test/merkle_tree.test.ts
+++ b/test/merkle_tree.test.ts
@@ -9,8 +9,7 @@ import {
   convertFieldToAddress,
   generateLeaves,
 } from "@sealance-io/policy-engine-aleo";
-import { Account } from "@provablehq/sdk";
-import { generateAddressesParallel } from "./utils/Accounts";
+import { generateAddressesParallel, safeAddress } from "./utils/Accounts";
 
 const mode = ExecutionMode.SnarkExecute;
 const contract = new Merkle_treeContract({ mode });
@@ -25,7 +24,7 @@ describe("merkle_tree program tests", () => {
     const size = 2 ** depth;
     const addresses = Array(size)
       .fill(null)
-      .map(() => new Account().address().to_string());
+      .map(() => safeAddress());
     const sortedAddresses = addresses
       .map(addr => ({
         address: addr,
@@ -41,7 +40,7 @@ describe("merkle_tree program tests", () => {
     // Generate a new address that's guaranteed to be larger than the smallest and smaller than the largest
     let newAddress = smallestAddress;
     while (convertAddressToField(newAddress) <= smallestField || convertAddressToField(newAddress) >= largestField) {
-      newAddress = new Account().address().to_string();
+      newAddress = safeAddress();
     }
 
     sortedAddresses[0] = {
@@ -51,7 +50,7 @@ describe("merkle_tree program tests", () => {
     // Generate a new address that's guaranteed to be larger than the smallest and smaller than the largest
     newAddress = largestAddress;
     while (convertAddressToField(newAddress) <= smallestField || convertAddressToField(newAddress) >= largestField) {
-      newAddress = new Account().address().to_string();
+      newAddress = safeAddress();
     }
     sortedAddresses[size - 1] = {
       address: newAddress,
@@ -99,7 +98,7 @@ describe("merkle_tree program tests", () => {
     // Generate a new address that's guaranteed to be larger than the smallest
     let newAddress = smallestAddress;
     while (convertAddressToField(newAddress) <= sortedAddresses[0].field) {
-      newAddress = new Account().address().to_string();
+      newAddress = safeAddress();
     }
 
     sortedAddresses[0] = {
@@ -110,7 +109,7 @@ describe("merkle_tree program tests", () => {
     // Generate a new address that's guaranteed to be smaller than the largest
     newAddress = largestAddress;
     while (convertAddressToField(newAddress) >= sortedAddresses[size - 1].field) {
-      newAddress = new Account().address().to_string();
+      newAddress = safeAddress();
     }
 
     sortedAddresses[size - 1] = {
@@ -152,7 +151,7 @@ describe("merkle_tree program tests", () => {
     const sortedAddresses = generateLeaves(addresses, depth);
     const tree = buildTree(sortedAddresses);
 
-    const checkedAddress = new Account().address().to_string();
+    const checkedAddress = safeAddress();
     const [leftLeafIndex, rightLeafIndex] = getLeafIndices(tree, checkedAddress);
 
     const merkleProof0 = getSiblingPath(tree, leftLeafIndex, MAX_TREE_DEPTH);
@@ -178,7 +177,7 @@ describe("merkle_tree program tests", () => {
     const sortedAddresses = generateLeaves(addresses, depth);
     const tree = buildTree(sortedAddresses);
 
-    const checkedAddress = new Account().address().to_string();
+    const checkedAddress = safeAddress();
     const [leftLeafIndex, rightLeafIndex] = getLeafIndices(tree, checkedAddress);
 
     const merkleProof0 = getSiblingPath(tree, leftLeafIndex, MAX_TREE_DEPTH);

--- a/test/multisig_compliant_token.test.ts
+++ b/test/multisig_compliant_token.test.ts
@@ -31,7 +31,8 @@ import {
 import { getLeafIndices, getSiblingPath } from "../lib/FreezeList";
 import { fundWithCredits } from "../lib/Fund";
 import { deployIfNotDeployed } from "../lib/Deploy";
-import { Account, AleoNetworkClient } from "@provablehq/sdk";
+import { AleoNetworkClient } from "@provablehq/sdk";
+import { safeAddress, safeAccount } from "./utils/Accounts";
 import { decryptToken } from "../artifacts/js/leo2js/multisig_compliant_token";
 import { Token } from "../artifacts/js/types/multisig_compliant_token";
 import { Credentials } from "../artifacts/js/types/multisig_compliant_token";
@@ -137,10 +138,10 @@ const multiSigContract = new Multisig_coreContract({
   privateKey: deployerPrivKey,
 });
 
-const managerWalletId = new Account().address().to_string();
-const pauseWalletId = new Account().address().to_string();
-const minterWalletId = new Account().address().to_string();
-const burnerWalletId = new Account().address().to_string();
+const managerWalletId = safeAddress();
+const pauseWalletId = safeAddress();
+const minterWalletId = safeAddress();
+const burnerWalletId = safeAddress();
 
 const amount = 10n;
 let root: bigint;
@@ -577,7 +578,7 @@ describe("test multisig_compliant_token program", () => {
     role = await tokenContract.address_to_role(adminAddress);
     expect(role).toBe(MANAGER_ROLE);
 
-    const randomAddress = new Account().address().to_string();
+    const randomAddress = safeAddress();
     const randomRole = [MANAGER_ROLE, BURNER_ROLE, MINTER_ROLE, PAUSE_ROLE, MINTER_ROLE + BURNER_ROLE][
       Math.floor(Math.random() * 5)
     ];
@@ -723,7 +724,7 @@ describe("test multisig_compliant_token program", () => {
     let tokenInfo = await tokenContract.token_info(true);
     const supply = tokenInfo.supply;
 
-    const randomAccount = new Account();
+    const randomAccount = safeAccount();
     const randomPrivKey = randomAccount.privateKey().to_string();
     const randomAddress = randomAccount.address().to_string();
     const salt = BigInt(Math.floor(Math.random() * 100000));
@@ -853,7 +854,7 @@ describe("test multisig_compliant_token program", () => {
     let tokenInfo = await tokenContract.token_info(true);
     const supply = tokenInfo.supply;
 
-    const randomAddress = new Account().address().to_string();
+    const randomAddress = safeAddress();
     const salt = BigInt(Math.floor(Math.random() * 100000));
     const multisigOp = {
       op: MULTISIG_OP_MINT_PUBLIC,
@@ -1408,7 +1409,7 @@ describe("test multisig_compliant_token program", () => {
     // It's impossible to get the credentials record with an invalid merkle proof
     await expect(tokenContractForFrozenAccount.get_credentials(frozenAccountMerkleProof)).rejects.toThrow();
 
-    const randomAddress = new Account().address().to_string();
+    const randomAddress = safeAddress();
     const leaves = generateLeaves([randomAddress]);
     const tree = buildTree(leaves);
     const senderLeafIndices = getLeafIndices(tree, account);
@@ -1758,7 +1759,7 @@ describe("test multisig_compliant_token program", () => {
   });
 
   test(`test expired multisig requests`, async () => {
-    const randomWalletId = new Account().address().to_string();
+    const randomWalletId = safeAddress();
     await createWallet(randomWalletId, 1, [deployerAddress, ZERO_ADDRESS, ZERO_ADDRESS, ZERO_ADDRESS]);
     const updateWalletTx = await tokenContractForAdmin.update_wallet_id_role(
       randomWalletId,

--- a/test/multisig_freeze_registry.test.ts
+++ b/test/multisig_freeze_registry.test.ts
@@ -27,7 +27,7 @@ import { fundWithCredits } from "../lib/Fund";
 import { deployIfNotDeployed } from "../lib/Deploy";
 import { Multisig_freezelist_registryContract } from "../artifacts/js/multisig_freezelist_registry";
 import { buildTree, generateLeaves } from "@sealance-io/policy-engine-aleo";
-import { Account } from "@provablehq/sdk";
+import { safeAddress } from "./utils/Accounts";
 import { isProgramInitialized } from "../lib/Initalize";
 import { Multisig_coreContract } from "../artifacts/js/multisig_core";
 import { approveRequest, createWallet, initializeMultisig } from "../lib/Multisig";
@@ -70,8 +70,8 @@ const multiSigContract = new Multisig_coreContract({
   privateKey: deployerPrivKey,
 });
 
-const managerWalletId = new Account().address().to_string();
-const freezeListManagerWalletId = new Account().address().to_string();
+const managerWalletId = safeAddress();
+const freezeListManagerWalletId = safeAddress();
 
 let root: bigint;
 
@@ -566,7 +566,7 @@ describe("test multisig freeze registry program", () => {
     );
     await expect(rejectedTx.wait()).rejects.toThrow();
 
-    let randomAddress = new Account().address().to_string();
+    let randomAddress = safeAddress();
     let tx = await freezeRegistryContractForFreezeListManager.update_freeze_list(
       randomAddress,
       true,
@@ -584,7 +584,7 @@ describe("test multisig freeze registry program", () => {
     expect(frozenAccountByIndex).toBe(randomAddress);
     expect(lastIndex).toBe(2);
 
-    randomAddress = new Account().address().to_string();
+    randomAddress = safeAddress();
     // Cannot freeze an account when the frozen list index is greater than the last index
     rejectedTx = await freezeRegistryContractForFreezeListManager.update_freeze_list(
       randomAddress,
@@ -606,7 +606,7 @@ describe("test multisig freeze registry program", () => {
     );
     await expect(rejectedTx.wait()).rejects.toThrow();
 
-    randomAddress = new Account().address().to_string();
+    randomAddress = safeAddress();
 
     // Even though the caller is a freeze list manager, a non-ZERO wallet_id triggers a multisig check,
     // which fails because no such request exists.
@@ -679,17 +679,10 @@ describe("test multisig freeze registry program", () => {
     await expect(rejectedTx.wait()).rejects.toThrow();
 
     // If the address doesn't match the address in the request the transaction will fail
-    rejectedTx = await freezeRegistryContract.update_freeze_list(
-      new Account().address().to_string(),
-      true,
-      3,
-      root,
-      root,
-      {
-        wallet_id: freezeListManagerWalletId,
-        salt,
-      },
-    );
+    rejectedTx = await freezeRegistryContract.update_freeze_list(safeAddress(), true, 3, root, root, {
+      wallet_id: freezeListManagerWalletId,
+      salt,
+    });
     await expect(rejectedTx.wait()).rejects.toThrow();
     // If the is_frozen doesn't match the is_frozen in the request the transaction will fail
     rejectedTx = await freezeRegistryContract.update_freeze_list(randomAddress, false, 3, root, root, {
@@ -910,7 +903,7 @@ describe("test multisig freeze registry program", () => {
   });
 
   test(`test expired multisig requests`, async () => {
-    const randomWalletId = new Account().address().to_string();
+    const randomWalletId = safeAddress();
     await createWallet(randomWalletId, 1, [deployerAddress, ZERO_ADDRESS, ZERO_ADDRESS, ZERO_ADDRESS]);
     const updateWalletTx = await freezeRegistryContractForAdmin.update_wallet_id_role(
       randomWalletId,

--- a/test/multisig_freezelist_proxy.test.ts
+++ b/test/multisig_freezelist_proxy.test.ts
@@ -19,7 +19,7 @@ import {
 } from "../lib/Constants";
 import { fundWithCredits } from "../lib/Fund";
 import { deployIfNotDeployed } from "../lib/Deploy";
-import { Account } from "@provablehq/sdk";
+import { safeAddress } from "./utils/Accounts";
 import { initializeProgram, isProgramInitialized } from "../lib/Initalize";
 import { Multisig_coreContract } from "../artifacts/js/multisig_core";
 import { approveRequest, createWallet, initializeMultisig } from "../lib/Multisig";
@@ -64,8 +64,8 @@ const freezeRegistryProxyContractForAdmin = new Multisig_freezelist_proxyContrac
   privateKey: adminPrivKey,
 });
 
-const managerWalletId = new Account().address().to_string();
-const freezeListManagerWalletId = new Account().address().to_string();
+const managerWalletId = safeAddress();
+const freezeListManagerWalletId = safeAddress();
 
 const root = 1n;
 
@@ -382,7 +382,7 @@ describe("test multisig_freezelist_proxy program", () => {
   test(`test update_freeze_list`, async () => {
     const currentRoot = await freezeRegistryContract.freeze_list_root(CURRENT_FREEZE_LIST_ROOT_INDEX);
     const lastIndex = await freezeRegistryContract.freeze_list_last_index(FREEZE_LIST_LAST_INDEX);
-    const randomAddress = new Account().address().to_string();
+    const randomAddress = safeAddress();
 
     const salt = BigInt(Math.floor(Math.random() * 100000));
     const multisigOp = {
@@ -449,7 +449,7 @@ describe("test multisig_freezelist_proxy program", () => {
 
     // If the address doesn't match the address in the request the transaction will fail
     rejectedTx = await freezeRegistryProxyContract.update_freeze_list(
-      new Account().address().to_string(),
+      safeAddress(),
       true,
       multisigOp.frozen_index,
       currentRoot,

--- a/test/multisig_token_proxy.test.ts
+++ b/test/multisig_token_proxy.test.ts
@@ -18,7 +18,7 @@ import {
 } from "../lib/Constants";
 import { fundWithCredits } from "../lib/Fund";
 import { deployIfNotDeployed } from "../lib/Deploy";
-import { Account } from "@provablehq/sdk";
+import { safeAddress } from "./utils/Accounts";
 import { decryptToken } from "../artifacts/js/leo2js/compliant_token_template";
 import { Merkle_treeContract } from "../artifacts/js/merkle_tree";
 import { initializeProgram } from "../lib/Initalize";
@@ -84,10 +84,10 @@ const tokenProxyContractForFrozenAccount = new Multisig_token_proxyContract({
   mode,
   privateKey: frozenAccountPrivKey,
 });
-const managerWalletId = new Account().address().to_string();
-const pauseWalletId = new Account().address().to_string();
-const minterWalletId = new Account().address().to_string();
-const burnerWalletId = new Account().address().to_string();
+const managerWalletId = safeAddress();
+const pauseWalletId = safeAddress();
+const minterWalletId = safeAddress();
+const burnerWalletId = safeAddress();
 
 const amount = 10n;
 
@@ -337,7 +337,7 @@ describe("test multisig token proxy program", () => {
   });
 
   test(`test update_role`, async () => {
-    const randomAddress = new Account().address().to_string();
+    const randomAddress = safeAddress();
     const randomRole = [MANAGER_ROLE, BURNER_ROLE, MINTER_ROLE, PAUSE_ROLE, MINTER_ROLE + BURNER_ROLE][
       Math.floor(Math.random() * 5)
     ];

--- a/test/report_policy.test.ts
+++ b/test/report_policy.test.ts
@@ -28,7 +28,7 @@ import { deployIfNotDeployed } from "../lib/Deploy";
 import { registerTokenProgram } from "../lib/Token";
 import { buildTree, generateLeaves } from "@sealance-io/policy-engine-aleo";
 import type { Token } from "../artifacts/js/types/token_registry";
-import { Account } from "@provablehq/sdk";
+import { safeAddress } from "./utils/Accounts";
 import { isProgramInitialized } from "../lib/Initalize";
 import { Multisig_coreContract } from "../artifacts/js/multisig_core";
 
@@ -318,7 +318,7 @@ describe("test sealed_report_policy program", () => {
     expect(frozenAccountByIndex).toBe(frozenAccount);
     expect(lastIndex).toBe(1);
 
-    let randomAddress = new Account().address().to_string();
+    let randomAddress = safeAddress();
     tx = await reportPolicyContractForFreezeListManager.update_freeze_list(randomAddress, true, 2, root, root);
     await tx.wait();
     isAccountFrozen = await reportPolicyContract.freeze_list(randomAddress);
@@ -329,7 +329,7 @@ describe("test sealed_report_policy program", () => {
     expect(frozenAccountByIndex).toBe(randomAddress);
     expect(lastIndex).toBe(2);
 
-    randomAddress = new Account().address().to_string();
+    randomAddress = safeAddress();
     // Cannot freeze an account when the frozen list index is greater than the last index
     rejectedTx = await reportPolicyContractForFreezeListManager.update_freeze_list(randomAddress, true, 10, root, root);
     await expect(rejectedTx.wait()).rejects.toThrow();

--- a/test/report_token.test.ts
+++ b/test/report_token.test.ts
@@ -23,7 +23,7 @@ import { getLeafIndices, getSiblingPath } from "../lib/FreezeList";
 import { fundWithCredits } from "../lib/Fund";
 import { deployIfNotDeployed } from "../lib/Deploy";
 import { buildTree, generateLeaves, stringToBigInt } from "@sealance-io/policy-engine-aleo";
-import { Account } from "@provablehq/sdk";
+import { safeAddress } from "./utils/Accounts";
 import { Sealed_report_tokenContract } from "../artifacts/js/sealed_report_token";
 import { decryptToken } from "../artifacts/js/leo2js/sealed_report_token";
 import { Token } from "../artifacts/js/types/sealed_report_token";
@@ -436,7 +436,7 @@ describe("test sealed_report_token program", () => {
     expect(frozenAccountByIndex).toBe(frozenAccount);
     expect(lastIndex).toBe(1);
 
-    let randomAddress = new Account().address().to_string();
+    let randomAddress = safeAddress();
     tx = await reportTokenContractForFreezeListManager.update_freeze_list(randomAddress, true, 2, root, root);
     await tx.wait();
     isAccountFrozen = await reportTokenContractForAdmin.freeze_list(randomAddress);
@@ -447,7 +447,7 @@ describe("test sealed_report_token program", () => {
     expect(frozenAccountByIndex).toBe(randomAddress);
     expect(lastIndex).toBe(2);
 
-    randomAddress = new Account().address().to_string();
+    randomAddress = safeAddress();
     // Cannot freeze an account when the frozen list index is greater than the last index
     rejectedTx = await reportTokenContractForFreezeListManager.update_freeze_list(randomAddress, true, 10, root, root);
     await expect(rejectedTx.wait()).rejects.toThrow();

--- a/test/utils/Accounts.ts
+++ b/test/utils/Accounts.ts
@@ -10,11 +10,21 @@ import { Account } from "@provablehq/sdk";
 // Unreachable types are included for defense-in-depth.
 const LEO_TYPE_SUFFIXES = [
   // unsigned integers
-  "u128", "u64", "u32", "u16", "u8",
+  "u128",
+  "u64",
+  "u32",
+  "u16",
+  "u8",
   // signed integers
-  "i128", "i64", "i32", "i16", "i8",
+  "i128",
+  "i64",
+  "i32",
+  "i16",
+  "i8",
   // other primitive types
-  "scalar", "field", "group",
+  "scalar",
+  "field",
+  "group",
 ];
 
 function hasDangerousSuffix(address: string): boolean {

--- a/test/utils/Accounts.ts
+++ b/test/utils/Accounts.ts
@@ -1,5 +1,41 @@
 import { Worker } from "worker_threads";
 import os from "os";
+import { Account } from "@provablehq/sdk";
+
+// Leo CLI parses arguments with these suffixes as typed literals, causing it to
+// reject valid Aleo addresses. Listed longest-first so the most-specific suffix
+// matches first. Reachability from the bech32 charset (excludes '1','b','i','o'):
+//   Reachable:   u8 (~1/1 024), u32 (~1/32 768), u64 (~1/32 768), scalar (~1/32^6)
+//   Unreachable: u16, u128 (need '1')  |  i-types, field (need 'i')  |  group (needs 'o')
+// Unreachable types are included for defense-in-depth.
+const LEO_TYPE_SUFFIXES = [
+  // unsigned integers
+  "u128", "u64", "u32", "u16", "u8",
+  // signed integers
+  "i128", "i64", "i32", "i16", "i8",
+  // other primitive types
+  "scalar", "field", "group",
+];
+
+function hasDangerousSuffix(address: string): boolean {
+  return LEO_TYPE_SUFFIXES.some(s => address.endsWith(s));
+}
+
+export function safeAddress(): string {
+  let addr: string;
+  do {
+    addr = new Account().address().to_string();
+  } while (hasDangerousSuffix(addr));
+  return addr;
+}
+
+export function safeAccount(): Account {
+  let account: Account;
+  do {
+    account = new Account();
+  } while (hasDangerousSuffix(account.address().to_string()));
+  return account;
+}
 
 export async function generateAddressesParallel(
   totalCount: number,
@@ -13,16 +49,23 @@ export async function generateAddressesParallel(
   // Use inline worker code to avoid file resolution issues
   const workerCode = `
     const { workerData, parentPort } = require('worker_threads');
-    
+
     // Dynamic import for ESM module
     (async () => {
       const { Account } = await import('@provablehq/sdk');
-      
+
+      const DANGEROUS = ['u128','u64','u32','u16','u8','i128','i64','i32','i16','i8','scalar','field','group'];
+      function isSafe(addr) {
+        return !DANGEROUS.some(s => addr.endsWith(s));
+      }
+
       const addresses = [];
-      for (let i = 0; i < workerData.count; i++) {
-        const account = new Account();
-        addresses.push(account.address().to_string());
-        
+      while (addresses.length < workerData.count) {
+        const addr = new Account().address().to_string();
+        if (!isSafe(addr)) continue;
+        addresses.push(addr);
+
+        const i = addresses.length;
         if (i % 100 === 0) {
           parentPort.postMessage({
             type: 'progress',
@@ -31,7 +74,7 @@ export async function generateAddressesParallel(
           });
         }
       }
-      
+
       parentPort.postMessage({
         type: 'complete',
         addresses


### PR DESCRIPTION
# Guard random address generation against Leo CLI type-suffix misparsing

## Problem

The Leo CLI argument parser applies **type-suffix detection to all positional arguments**.
Any string ending with a Leo type suffix — `u8`, `u32`, `u64`, etc. — is interpreted as a
typed numeric literal and rejected, even when the string is a valid Aleo address.

Aleo addresses are bech32-encoded, drawing from a 32-character alphabet that excludes
`1`, `b`, `i`, and `o`. This leaves three integer suffixes reachable at module
initialisation time or inside test bodies wherever `new Account()` is called:

| Suffix | Probability per address |
| ------ | ----------------------- |
| `u8`   | ~1 / 1,024 (dominant)   |
| `u32`  | ~1 / 32,768             |
| `u64`  | ~1 / 32,768             |

**Combined: ~1 / 964.** With multiple random addresses generated per test file and
hundreds of CI runs, failures are statistically inevitable. The failure is non-deterministic
and produces a misleading error unrelated to the code under test:

```
Error [ECLI0377045]: Invalid u8 literal: 'aleo1vnx8f43f7yjvs2ehlqsl78j2qh4409s8e4g7gx40u3v884gqgqxqscutu8' is not a valid numeric value
```

A full bug report for the Leo CLI has been filed separately: see <TBD>.

## Fix

Introduce two exports in `test/utils/Accounts.ts` that regenerate until the address
carries no dangerous suffix (expected: ≤ 2 iterations in practice):

```typescript
safeAddress(): string   // drop-in for new Account().address().to_string()
safeAccount(): Account  // for cases that also need the private key
```

The suffix list covers **all Leo primitive types** — including those currently unreachable
from bech32 (`u16`, `u128`, all `i*`, `field`, `group`) — for defense-in-depth against
future parser changes. The `generateAddressesParallel` worker applies the same filter
inline.

## Changes

| File                                     | Change                                                                      |
| ---------------------------------------- | --------------------------------------------------------------------------- |
| `test/utils/Accounts.ts`                 | Add `safeAddress`, `safeAccount`, harden `generateAddressesParallel` worker |
| `test/merkle_tree.test.ts`               | Replace 7 raw `new Account()` calls                                         |
| `test/multisig_compliant_token.test.ts`  | Replace 7 calls; `safeAccount()` for full-object case                       |
| `test/multisig_freeze_registry.test.ts`  | Replace 7 calls                                                             |
| `test/multisig_freezelist_proxy.test.ts` | Replace 4 calls                                                             |
| `test/multisig_token_proxy.test.ts`      | Replace 5 calls                                                             |
| `test/compliant_token.test.ts`           | Replace 1 call                                                              |
| `test/freeze_registry.test.ts`           | Replace 2 calls                                                             |
| `test/report_policy.test.ts`             | Replace 2 calls                                                             |
| `test/report_token.test.ts`              | Replace 2 calls                                                             |

No production code, Leo programs, or SDK code was modified.

## Verification

```bash
# Confirm no raw new Account() calls remain in integration tests
grep -rn "new Account()" test/

# Expected output: only the safe implementations inside test/utils/Accounts.ts itself
```
